### PR TITLE
Support focus command.

### DIFF
--- a/lib/furble/CanonEOSM6.cpp
+++ b/lib/furble/CanonEOSM6.cpp
@@ -231,6 +231,11 @@ void CanonEOSM6::shutterRelease(void) {
               &x[0], 2);
 }
 
+void CanonEOSM6::shutterFocus(void) {
+  // Unimplemented
+  return;
+}
+
 void CanonEOSM6::disconnect(void) {
   m_Client->disconnect();
 }

--- a/lib/furble/FujifilmXT30.cpp
+++ b/lib/furble/FujifilmXT30.cpp
@@ -36,6 +36,7 @@ static const char *FUJI_XT30_CHR_SHUTTER_UUID = "7fcf49c6-4ff0-4777-a03d-1a79166
 static const uint8_t FUJI_XT30_SHUTTER_CMD[2] = {0x01, 0x00};
 static const uint8_t FUJI_XT30_SHUTTER_PRESS[2] = {0x02, 0x00};
 static const uint8_t FUJI_XT30_SHUTTER_RELEASE[2] = {0x00, 0x00};
+static const uint8_t FUJI_XT30_SHUTTER_FOCUS[2] = {0x03, 0x00};
 
 namespace Furble {
 
@@ -176,6 +177,14 @@ void FujifilmXT30::shutterRelease(void)
   NimBLERemoteCharacteristic *pChr = pSvc->getCharacteristic(FUJI_XT30_CHR_SHUTTER_UUID);
   pChr->writeValue(&FUJI_XT30_SHUTTER_CMD[0], sizeof(FUJI_XT30_SHUTTER_CMD), true);
   pChr->writeValue(&FUJI_XT30_SHUTTER_RELEASE[0], sizeof(FUJI_XT30_SHUTTER_RELEASE), true);
+}
+
+void FujifilmXT30::shutterFocus(void)
+{
+  NimBLERemoteService *pSvc = m_Client->getService(FUJI_XT30_SVC_SHUTTER_UUID);
+  NimBLERemoteCharacteristic *pChr = pSvc->getCharacteristic(FUJI_XT30_CHR_SHUTTER_UUID);
+  pChr->writeValue(&FUJI_XT30_SHUTTER_CMD[0], sizeof(FUJI_XT30_SHUTTER_CMD), true);
+  pChr->writeValue(&FUJI_XT30_SHUTTER_FOCUS[0], sizeof(FUJI_XT30_SHUTTER_RELEASE), true);
 }
 
 void FujifilmXT30::print(void)

--- a/lib/furble/FujifilmXT30.cpp
+++ b/lib/furble/FujifilmXT30.cpp
@@ -184,7 +184,7 @@ void FujifilmXT30::shutterFocus(void)
   NimBLERemoteService *pSvc = m_Client->getService(FUJI_XT30_SVC_SHUTTER_UUID);
   NimBLERemoteCharacteristic *pChr = pSvc->getCharacteristic(FUJI_XT30_CHR_SHUTTER_UUID);
   pChr->writeValue(&FUJI_XT30_SHUTTER_CMD[0], sizeof(FUJI_XT30_SHUTTER_CMD), true);
-  pChr->writeValue(&FUJI_XT30_SHUTTER_FOCUS[0], sizeof(FUJI_XT30_SHUTTER_RELEASE), true);
+  pChr->writeValue(&FUJI_XT30_SHUTTER_FOCUS[0], sizeof(FUJI_XT30_SHUTTER_FOCUS), true);
 }
 
 void FujifilmXT30::print(void)

--- a/lib/furble/Furble.h
+++ b/lib/furble/Furble.h
@@ -59,6 +59,11 @@ class Device {
      */
     virtual void shutterRelease(void)=0;
 
+    /**
+     * Send a shutter button focus command.
+     */
+    virtual void shutterFocus(void)=0;
+
     const char *getName(void);
     void save(void);
     void remove(void);
@@ -102,6 +107,7 @@ class FujifilmXT30: public Device {
     bool connect(NimBLEClient *pClient, ezProgressBar &progress_bar);
     void shutterPress(void);
     void shutterRelease(void);
+    void shutterFocus(void);
     void disconnect(void);
     void print(void);
 
@@ -128,6 +134,7 @@ class CanonEOSM6: public Device {
     bool connect(NimBLEClient *pClient, ezProgressBar &progress_bar);
     void shutterPress(void);
     void shutterRelease(void);
+    void shutterFocus(void);
     void disconnect(void);
 
   private:

--- a/src/furble.ino
+++ b/src/furble.ino
@@ -26,9 +26,15 @@ class AdvertisedCallback: public NimBLEAdvertisedDeviceCallbacks {
 
 static void remote_control(Furble::Device *device) {
   Serial.println("Remote Control");
-  ez.msgBox("Remote Shutter", "Shutter Control: A\nBack: B", "", false);
+  ez.msgBox("Remote Shutter", "Shutter Control: A\nFocus: B\nBack: Power", "", false);
   while (true) {
     m5.update();
+
+    // Source code in AXP192 says 0x02 is short press.
+    if (m5.Axp.GetBtnPress() == 0x02) {
+      break;
+    }
+
     if (m5.BtnA.wasPressed()) {
       device->shutterPress();
     }
@@ -38,7 +44,11 @@ static void remote_control(Furble::Device *device) {
     }
 
     if (m5.BtnB.wasPressed()) {
-      break;
+      device->shutterFocus();
+    }
+
+    if (m5.BtnB.wasReleased()) {
+      device->shutterRelease();
     }
 
     delay(50);


### PR DESCRIPTION
Modify the shutter menu, now:
A: Trigger shutter
B: Hold until focus
PWR: Back

Sending '0x03' on the shutter characteristic (for Fujifilm) appears to activate a partial shutter press, thus simulating the physical 'partial press to focus'.

Canon EOS M6 is unsupported for now, need to regain access to test.