### PR TITLE
Add indication handling for the pairing accept/deny for Canon EOS.

### DIFF
--- a/lib/furble/CanonEOS.cpp
+++ b/lib/furble/CanonEOS.cpp
@@ -79,6 +79,13 @@ bool CanonEOS::write_prefix(NimBLEClient *pClient,
 bool CanonEOS::connect(NimBLEClient *pClient, ezProgressBar &progress_bar) {
   m_Client = pClient;
 
+  if (NimBLEDevice::isBonded(m_Address)) {
+    // Already bonded? Assume pair acceptance!
+    pair_result = CANON_EOS_PAIR_ACCEPT;
+  } else {
+    pair_result = 0x00;
+  }
+
   Serial.println("Connecting");
   if (!m_Client->connect(m_Address)) {
     Serial.println("Connection failed!!!");

--- a/lib/furble/CanonEOS.h
+++ b/lib/furble/CanonEOS.h
@@ -39,6 +39,9 @@ class CanonEOS: public Device {
   /** 0xf311 */
   const char *CANON_EOS_CHR_SHUTTER_UUID = "00030030-0000-1000-0000-d8492fffa821";
 
+  const uint8_t CANON_EOS_PAIR_ACCEPT = 0x02;
+  const uint8_t CANON_EOS_PAIR_REJECT = 0x03;
+
   bool write_value(NimBLEClient *pClient,
                    const char *serviceUUID,
                    const char *characteristicUUID,
@@ -52,7 +55,7 @@ class CanonEOS: public Device {
                     uint8_t *data,
                     size_t length);
 
-  bool connect(NimBLEClient *pClient, ezProgressBar &progress_bar, uint32_t pair_delay = 0);
+  bool connect(NimBLEClient *pClient, ezProgressBar &progress_bar);
   void shutterPress(void);
   void shutterRelease(void);
   void focusPress(void);

--- a/lib/furble/CanonEOSRP.cpp
+++ b/lib/furble/CanonEOSRP.cpp
@@ -45,7 +45,7 @@ bool CanonEOSRP::matches(NimBLEAdvertisedDevice *pDevice) {
  * handled by the underlying NimBLE and ESP32 libraries.
  */
 bool CanonEOSRP::connect(NimBLEClient *pClient, ezProgressBar &progress_bar) {
-  return CanonEOS::connect(pClient, progress_bar, 5000);
+  return CanonEOS::connect(pClient, progress_bar);
 }
 
 device_type_t CanonEOSRP::getDeviceType(void) {

--- a/lib/furble/Fujifilm.cpp
+++ b/lib/furble/Fujifilm.cpp
@@ -94,10 +94,10 @@ bool Fujifilm::matches(NimBLEAdvertisedDevice *pDevice) {
 }
 
 /**
- * Connect to a Fujifilm X-T30.
+ * Connect to a Fujifilm.
  *
- * During initial pairing the X-T30 advertisement includes a pairing token, this
- * token is what we use to identify ourselves upfront and during subsequent
+ * During initial pairing the advertisement includes a pairing token, this token
+ * is what we use to identify ourselves upfront and during subsequent
  * re-pairing.
  */
 bool Fujifilm::connect(NimBLEClient *pClient, ezProgressBar &progress_bar) {


### PR DESCRIPTION
We now wait for 60s for the user to accept/reject the pairing.
Whilst here, disable the focus button so it doesn't do the unexpected.