### PR TITLE
Add support for M5Stack Core2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,3 +42,6 @@ jobs:
 
       - name: Build furble (M5StickC Plus)
         run: platformio run -e m5stick-c-plus
+
+      - name: Build furble (M5Stack Core2)
+        run: platformio run -e m5stack-core2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ env:
   FURBLE_VERSION: ${{ github.ref_name }}+${{ github.run_attempt }}
   M5STICKC_FIRMWARE: furble-m5stick-c-${{ github.ref_name }}+${{ github.run_attempt }}.bin
   M5STICKC_PLUS_FIRMWARE: furble-m5stick-c-plus-${{ github.ref_name }}+${{ github.run_attempt }}.bin
+  M5STACK_CORE2_FIRMWARE: furble-m5stack-core2-${{ github.ref_name }}+${{ github.run_attempt }}.bin
 
 jobs:
   build:
@@ -39,9 +40,14 @@ jobs:
           platformio run -e m5stick-c-plus
           cp -v .pio/build/m5stick-c-plus/firmware.bin $M5STICKC_PLUS_FIRMWARE
 
+      - name: Build furble (M5Stack Core2)
+        run: |
+          platformio run -e m5stack-core2
+          cp -v .pio/build/m5stack-core2/firmware.bin $M5STACK_CORE2_FIRMWARE
+
       - name: Generate release hashes
         run: |
-          sha256sum $M5STICKC_FIRMWARE $M5STICKC_PLUS_FIRMWARE > sha256sum.txt
+          sha256sum $M5STICKC_FIRMWARE $M5STICKC_PLUS_FIRMWARE $M5STACK_CORE2_FIRMWARE > sha256sum.txt
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -50,4 +56,5 @@ jobs:
           files: |
             ${{ env.M5STICKC_FIRMWARE }}
             ${{ env.M5STICKC_PLUS_FIRMWARE }}
+            ${{ env.M5STACK_CORE2_FIRMWARE }}
             sha256sum.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .pio
+.vscode

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The remote uses the camera's native Bluetooth Low Energy interface so additional
 adapters are not required.
 
 furble is developed as a PlatformIO project for the M5StickC and M5StickC Plus
-(ESP32 based devices).
+(ESP32 based devices). Additionally, it can be used on the M5Stack Core2.
 
 ## Supported Cameras
 
@@ -118,6 +118,8 @@ In most cases it should be:
     - `platformio run -e m5stick-c -t upload`
 - OR plug in the M5StickC Plus
     - `platformio run -e m5stick-c-plus -t upload`
+- OR plug in the M5Stack Core2
+    - `platformio run -e m5stack-core2 -t upload`
 
 ## Usage
 

--- a/lib/M5ez/src/M5ez.cpp
+++ b/lib/M5ez/src/M5ez.cpp
@@ -780,11 +780,7 @@ void ezSettings::defaults() {
 				while (true) {
 					if (m5.BtnA.wasPressed() || m5.BtnB.wasPressed()) break;
 					ez.yield();
-#if M5STICKC_PLUS
-                                        //m5.Axp.LightSleep(SLEEP_MSEC(10));
-                                        //On M5StickC-Plus, the screen blanks
-                                        //without recovery.
-#else
+#ifdef M5STICKC
 					m5.Axp.LightSleep(SLEEP_MSEC(10));
 #endif
 				}
@@ -2630,10 +2626,16 @@ void M5ez::setFont(const GFXfont* font) {
 }
 
 int16_t M5ez::fontHeight() {
-#if M5STICKC_PLUS
-  return m5.lcd.fontHeight(m5.lcd.textfont);
-#else
-  return 11;
+#ifdef M5STICKC_PLUS
+	return m5.lcd.fontHeight(m5.lcd.textfont);
+#endif
+
+#ifdef M5STACK_CORE2
+	return 26;
+#endif
+
+#ifdef M5STICKC
+	return 11;
 #endif
 }
 

--- a/lib/M5ez/src/M5ez.cpp
+++ b/lib/M5ez/src/M5ez.cpp
@@ -464,6 +464,7 @@ void ezCanvas::_putString(String text) {
 
 String ezButtons::_btn_a_s, ezButtons::_btn_a_l;
 String ezButtons::_btn_b_s, ezButtons::_btn_b_l;
+String ezButtons::_btn_c_s, ezButtons::_btn_c_l;
 bool ezButtons::_key_release_wait;
 bool ezButtons::_lower_button_row, ezButtons::_upper_button_row;  
 
@@ -475,12 +476,13 @@ void ezButtons::show(String buttons) {
 	ez.chopString(buttons, "#", buttonVector, true);
 	switch (buttonVector.size()) {
 		case 1:
-			_drawButtons("", "", buttons, "");
+			_drawButtons("", "", buttons, "", "", "", "", "", "");
 			break;
-                case 2:
+		case 2:
+			_drawButtons(buttonVector[0], "", buttonVector[1], "", "", "", "", "", "");
 		case 3:
 			// Three elements, so shortpress only
-			_drawButtons(buttonVector[0], "", buttonVector[1], "");
+			_drawButtons(buttonVector[0], "", buttonVector[1], "", buttonVector[2], "", "", "", "");
 			break;
 	}
 }
@@ -489,17 +491,17 @@ void ezButtons::clear(bool wipe /* = true */) {
 	if (wipe && (_lower_button_row  || _upper_button_row)) {
 		m5.lcd.fillRect(0, ez.canvas.bottom() + 1, TFT_H - ez.canvas.bottom() - 1, TFT_W, ez.screen.background());
 	}
-	_btn_a_s = _btn_a_l = _btn_b_s = _btn_b_l = "";
+	_btn_a_s = _btn_a_l = _btn_b_s = _btn_b_l = _btn_c_s = _btn_c_l ="";
 	_lower_button_row = false;
 	_upper_button_row = false;
 	ez.canvas.bottom(TFT_H - 1);
 }
 
-void ezButtons::_drawButtons(String btn_a_s, String btn_a_l, String btn_b_s, String btn_b_l) {
+void ezButtons::_drawButtons(String btn_a_s, String btn_a_l, String btn_b_s, String btn_b_l, String btn_c_s, String btn_c_l, String btn_ab, String btn_bc, String btn_ac) {
 	int16_t btnwidth = int16_t( (TFT_W - 4 * ez.theme->button_gap ) / 3);
 
 	// See if any buttons are used on the bottom row
-	if (btn_a_s != "" || btn_a_l != "" || btn_b_s != "" || btn_b_l != "") {
+	if (btn_a_s != "" || btn_a_l != "" || btn_b_s != "" || btn_b_l != "" || btn_c_s != "" || btn_c_l != "") {
 		if (!_lower_button_row) {
 			// If the lower button row wasn't there before, clear the area first
 			m5.lcd.fillRect(0, TFT_H - ez.theme->button_height - ez.theme->button_gap, TFT_W, ez.theme->button_height + ez.theme->button_gap, ez.screen.background());
@@ -515,12 +517,17 @@ void ezButtons::_drawButtons(String btn_a_s, String btn_a_l, String btn_b_s, Str
 			_btn_b_s = btn_b_s;
 			_btn_b_l = btn_b_l;		
 		}
+		if (_btn_c_s != btn_c_s || _btn_c_l != btn_c_l) {
+			_drawButton(1, ez.rightOf(btn_c_s, "|", true), ez.rightOf(btn_c_l, "|", true), 2 * btnwidth + 3 * ez.theme->button_gap, btnwidth);
+			_btn_c_s = btn_c_s;
+			_btn_c_l = btn_c_l;		
+		}
 		_lower_button_row = true;
 	} else {
 		if (_lower_button_row) {
 			// If there was a lower button row before and it's now gone, clear the area
 			m5.lcd.fillRect(0, TFT_H - ez.theme->button_height - ez.theme->button_gap, TFT_W, ez.theme->button_height + ez.theme->button_gap, ez.screen.background());
-			_btn_a_s = _btn_a_l = _btn_b_s = _btn_b_l = "";
+			_btn_a_s = _btn_a_l = _btn_b_s = _btn_b_l = _btn_c_s = _btn_c_l = "";
 			_lower_button_row = false;
 		}
 	}

--- a/lib/M5ez/src/M5ez.h
+++ b/lib/M5ez/src/M5ez.h
@@ -37,8 +37,12 @@
 #endif
 #ifdef M5STICKC_PLUS
 #include <M5StickCPlus.h>
-#else
+#endif
+#ifdef M5STICKC
 #include <M5StickC.h>		// GFXfont*
+#endif
+#ifdef M5STACK_CORE2
+#include <M5Core2.h>
 #endif
 #ifdef M5EZ_CLOCK
 	#include <ezTime.h>			// events, on-screen clock
@@ -70,13 +74,24 @@
 #define TFT_HEADER_HEIGHT 23
 #define TFT_BUTTON_HEIGHT 19
 #define TFT_RADIUS      8
-#else
+#endif
+
+#ifdef M5STICKC
 #define TFT_W		160
 #define TFT_H		80
 #define TFT_FONT        hzk16
 #define TFT_HEADER_HEIGHT 12
 #define TFT_BUTTON_HEIGHT 11
 #define TFT_RADIUS      3
+#endif
+
+#ifdef M5STACK_CORE2
+#define TFT_W		320
+#define TFT_H		240
+#define TFT_FONT        sans16
+#define TFT_HEADER_HEIGHT 23
+#define TFT_BUTTON_HEIGHT 19
+#define TFT_RADIUS      8
 #endif
 
 struct line_t {

--- a/lib/M5ez/src/M5ez.h
+++ b/lib/M5ez/src/M5ez.h
@@ -329,9 +329,10 @@ class ezButtons {
 	private:
 		static String _btn_a_s, _btn_a_l;
 		static String _btn_b_s, _btn_b_l;
+		static String _btn_c_s, _btn_c_l;
 		static bool _key_release_wait;
 		static bool _lower_button_row, _upper_button_row;
-		static void _drawButtons(String btn_a_s, String btn_a_l, String btn_b_s, String btn_b_l);
+		static void _drawButtons(String btn_a_s, String btn_a_l, String btn_b_s, String btn_b_l, String btn_c_s, String btn_c_l, String btn_ab, String btn_bc, String btn_ac);
 		static void _drawButton(int16_t row, String text_s, String text_l, int16_t x, int16_t w);
 		static void _drawButtonString(String text, int16_t x, int16_t y, uint16_t color, int16_t datum);
 	//

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ upload_protocol = esptool
 framework = arduino
 
 [env:m5stick-c]
-build_flags = ${furble.build_flags}
+build_flags = ${furble.build_flags} -D M5STICKC
 lib_deps =
   ${furble.lib_deps}
   M5StickC@0.2.5
@@ -22,3 +22,9 @@ build_flags = ${furble.build_flags} -D M5STICKC_PLUS
 lib_deps =
   ${furble.lib_deps}
   M5StickCPlus@0.0.8
+
+[env:m5stack-core2]
+build_flags = ${furble.build_flags} -D M5STACK_CORE2
+lib_deps =
+  ${furble.lib_deps}
+  M5Core2@0.1.7

--- a/src/furble.ino
+++ b/src/furble.ino
@@ -43,7 +43,7 @@ static void remote_control(Furble::Device *device) {
   Serial.println("Remote Control");
 
 #ifdef M5STACK_CORE2
-  ez.msgBox("Remote Shutter", "Back: C", "Release#Focus", false);
+  ez.msgBox("Remote Shutter", "", "Release#Focus#Back", false);
 #else
   ez.msgBox("Remote Shutter", "Back: Power", "Release#Focus", false);
 #endif

--- a/src/furble.ino
+++ b/src/furble.ino
@@ -4,8 +4,14 @@
 
 #ifdef M5STICKC_PLUS
 #include <M5StickCPlus.h>
-#else
+#endif
+
+#ifdef M5STICKC
 #include <M5StickC.h>
+#endif
+
+#ifdef M5STACK_CORE2
+#include <M5Core2.h>
 #endif
 
 const uint32_t SCAN_DURATION = 10;
@@ -35,14 +41,25 @@ static void about(void) {
 
 static void remote_control(Furble::Device *device) {
   Serial.println("Remote Control");
-  ez.msgBox("Remote Shutter", "Shutter Control: A\nFocus: B\nBack: Power", "", false);
+
+#ifdef M5STACK_CORE2
+  ez.msgBox("Remote Shutter", "Back: C", "Release#Focus", false);
+#else
+  ez.msgBox("Remote Shutter", "Back: Power", "Release#Focus", false);
+#endif
   while (true) {
     m5.update();
 
+#ifdef M5STACK_CORE2
+    if (m5.BtnC.wasPressed()) {
+      break;
+    }
+#else
     // Source code in AXP192 says 0x02 is short press.
     if (m5.Axp.GetBtnPress() == 0x02) {
       break;
     }
+#endif
 
     if (m5.BtnA.wasPressed()) {
       device->shutterPress();
@@ -171,6 +188,11 @@ void setup() {
 #include <themes/mono_furble.h>
 
   ez.begin();
+
+#ifdef M5STACK_CORE2
+  m5.lcd.setRotation(1);
+#endif
+
   NimBLEDevice::init(FURBLE_STR);
   NimBLEDevice::setSecurityAuth(true, true, true);
 


### PR DESCRIPTION
These changes enable usage with the [M5Stack Core2 ESP32 IoT Development Kit for AWS IoT Kit](https://shop.m5stack.com/products/m5stack-core2-esp32-iot-development-kit-for-aws-iot-edukit) device based on [M5Stack Core2](https://shop.m5stack.com/products/m5stack-core2-esp32-iot-development-kit).

This also modifies the included `M5ez` libraries for Core2 support. Maybe updating the library to a more recent version can make this obsolete; but I didn't want to go down that rabbit hole yet 😂

Tested with Fujifilm X-T5 v2.03