### PR TITLE
Fix high charge battery level mapping.

### DIFF
--- a/lib/M5ez/src/M5ez.cpp
+++ b/lib/M5ez/src/M5ez.cpp
@@ -2121,7 +2121,7 @@ uint16_t ezBattery::loop() {
 uint8_t ezBattery::getTransformedBatteryLevel() {
   int32_t level = M5.Power.getBatteryLevel();
 
-  return map(level, 0, 100, 0, 4);
+  return map(level, 0, 85, 0, 4);
 }
 
 // Return the theme based battery bar color according to its level


### PR DESCRIPTION
Lower the battery level max so 4 bars is 85-100%.
Otherwise, anything less than 100% is 3 bars.