### PR TITLE
Add support for web based installation.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,8 +115,8 @@ jobs:
         run: |
           mkdir -p deploy
           cp web-installer/index.html deploy/index.html
+          mv manifest*.json deploy/.
           mkdir -p deploy/firmware
-          mv manifest*.json deploy/firmware
           mv furble-*.bin deploy/firmware
 
       - name: Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           VERSION: ${{ env.FURBLE_VERSION }}
           PLATFORM: ${{ matrix.platform }}
         run: |
-          python generate-manifest.py > manifest_${{ matrix.platform }}.json
+          python generate-manifest.py > ../manifest_${{ matrix.platform }}.json
 
       - name: Upload artifacts (${{ matrix.platform }})
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,15 @@ jobs:
           mv .pio/build/${{ matrix.platform }}/partitions.bin $PARTITIONS_NAME
           mv ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin $BOOT_APP0_NAME
 
-      - name: Upload binary artifact (${{ matrix.platform }})
+      - name: Generate manifest (${{ matrix.platform }})
+        working-directory: ./web-installer
+        env:
+          VERSION: ${{ env.FURBLE_VERSION }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          python generate-manifest.py > manifest_${{ matrix.platform }}.json
+
+      - name: Upload artifacts (${{ matrix.platform }})
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.FIRMWARE_NAME }}
@@ -61,13 +69,14 @@ jobs:
             ${{ env.BOOTLOADER_NAME }}
             ${{ env.PARTITIONS_NAME }}
             ${{ env.BOOT_APP0_NAME }}
+            manifest_${{ matrix.platform.json }}
           if-no-files-found: error
 
   release:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Download binary artifacts
+      - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
@@ -83,4 +92,5 @@ jobs:
           generate_release_notes: true
           files: |
             furble-*.bin
+            manifest_*.json
             sha256sum.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           mv .pio/build/${{ matrix.platform }}/firmware.bin $FIRMWARE_NAME
           mv .pio/build/${{ matrix.platform }}/bootloader.bin $BOOTLOADER_NAME
           mv .pio/build/${{ matrix.platform }}/partitions.bin $PARTITIONS_NAME
-          mv ${{ env.HOME }}.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin $BOOT_APP0_NAME
+          mv ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin $BOOT_APP0_NAME
 
       - name: Upload binary artifact (${{ matrix.platform }})
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,3 +94,36 @@ jobs:
             furble-*.bin
             manifest_*.json
             sha256sum.txt
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    name: Deploy to Cloudflare Pages
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Assemble assets
+        run: |
+          mkdir -p deploy
+          cp web-installer/index.html deploy/index.html
+          mkdir -p deploy/firmware
+          mv manifest*.json deploy/firmware
+          mv furble-*.bin deploy/firmware
+
+      - name: Publish
+        uses: cloudflare/pages-action@1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: furble-web-installer
+          directory: deploy
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
 
     env:
       FIRMWARE_NAME: furble-${{ matrix.platform }}-${{ github.ref_name }}+${{ github.run_attempt }}.bin
+      BOOTLOADER_NAME: furble-bootloader-${{ matrix.platform }}-${{ github.ref_name }}+${{ github.run_attempt }}.bin
+      PARTITIONS_NAME: furble-partitions-${{ matrix.platform }}-${{ github.ref_name }}+${{ github.run_attempt }}.bin
+      BOOT_APP0_NAME: furble-boot-app0-${{ matrix.platform }}-${{ github.ref_name }}+${{ github.run_attempt }}.bin
 
     steps:
       - uses: actions/checkout@v4
@@ -42,14 +45,22 @@ jobs:
       - name: Build furble (${{ matrix.platform }})
         run: platformio run -e ${{ matrix.platform }}
 
-      - name: Rename binary (${{ matrix.platform}})
-        run: mv .pio/build/${{ matrix.platform }}/firmware.bin $FIRMWARE_NAME
+      - name: Rename binaries (${{ matrix.platform}})
+        run: |
+          mv .pio/build/${{ matrix.platform }}/firmware.bin $FIRMWARE_NAME
+          mv .pio/build/${{ matrix.platform }}/bootloader.bin $BOOTLOADER_NAME
+          mv .pio/build/${{ matrix.platform }}/partitions.bin $PARTITIONS_NAME
+          mv ${{ env.HOME }}.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin $BOOT_APP0_NAME
 
       - name: Upload binary artifact (${{ matrix.platform }})
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.FIRMWARE_NAME }}
-          path: ${{ env.FIRMWARE_NAME }}
+          path: |
+            ${{ env.FIRMWARE_NAME }}
+            ${{ env.BOOTLOADER_NAME }}
+            ${{ env.PARTITIONS_NAME }}
+            ${{ env.BOOT_APP0_NAME }}
           if-no-files-found: error
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
             ${{ env.BOOTLOADER_NAME }}
             ${{ env.PARTITIONS_NAME }}
             ${{ env.BOOT_APP0_NAME }}
-            manifest_${{ matrix.platform.json }}
+            manifest_${{ matrix.platform }}.json
           if-no-files-found: error
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,3 +127,4 @@ jobs:
           projectName: furble-web-installer
           directory: deploy
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          branch: main

--- a/web-installer/generate-manifest.py
+++ b/web-installer/generate-manifest.py
@@ -1,0 +1,14 @@
+from string import Template
+
+import os
+
+def generate(template: str, platform: str, version: str):
+    with open(template, "r") as f:
+        t = Template(f.read())
+        print(t.substitute({ "PLATFORM": platform, "VERSION" : version }))
+
+if __name__ == "__main__":
+    template = "manifest.tmpl"
+    platform = os.environ["PLATFORM"]
+    version = os.environ["VERSION"]
+    generate(template, platform, version)

--- a/web-installer/index.html
+++ b/web-installer/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="module" src="https://unpkg.com/esp-web-tools@10.0.1/dist/web/install-button.js?module"></script>
+    <style>
+      .radios li {
+        list-style: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="content">
+      <h1>furble web installer</h1>
+      <p>Flash furble firmware to a supported M5Stack device.</p>
+      <p>Select your device:</p>
+      <ul class="radios">
+        <li>
+          <label><input type="radio" name="type" value="m5stick-c"/>M5StickC</label>
+        </li>
+        <li>
+          <label><input type="radio" name="type" value="m5stick-c-plus"/>M5StickC Plus</label>
+        </li>
+        <li>
+          <label><input type="radio" name="type" value="m5stack-core"/>M5Stack Core</label>
+        </li>
+        <li>
+          <label><input type="radio" name="type" value="m5stack-core2"/>M5Stack Core2</label>
+        </li>
+      </ul>
+      <p class="button-row" align="left">
+        <esp-web-install-button class="invisible"></esp-web-install-button>
+      </p>
+
+      <div class="footer">
+        Installer powered by <a href="https://esphome.github.io/esp-web-tools/">ESP Web Tools</a>.
+      </div>
+    <script>
+      document.querySelectorAll('input[name="type"]').forEach(radio =>
+        radio.addEventListener("change", () => {
+          const button = document.querySelector('esp-web-install-button');
+          button.manifest = `./manifest_${radio.value}.json`;
+          button.classList.remove('invisible');
+        }
+      ));
+    </script>
+  </body>
+</html>

--- a/web-installer/index.html
+++ b/web-installer/index.html
@@ -32,6 +32,8 @@
       </p>
 
       <div class="footer">
+        Follow furble development <a href="https://github.com/gkoh/furble">here</a>
+        &mdash;
         Installer powered by <a href="https://esphome.github.io/esp-web-tools/">ESP Web Tools</a>.
       </div>
     <script>

--- a/web-installer/manifest.tmpl
+++ b/web-installer/manifest.tmpl
@@ -1,0 +1,17 @@
+{
+  "name": "furble",
+  "version": "$VERSION",
+  "new_install_prompt_erase": true,
+  "new_install_improv_wait_time": 0,
+  "builds": [
+    {
+      "chipFamily": "ESP32",
+      "parts": [
+        { "path": "firmware/furble-bootloader-$PLATFORM-$VERSION.bin", "offset": 4096 },
+        { "path": "firmware/furble-partitions-$PLATFORM-$VERSION.bin", "offset": 32768 },
+        { "path": "firmware/furble-boot-app0-$PLATFORM-$VERSION.bin", "offset": 57344 },
+        { "path": "firmware/furble-$PLATFORM-$VERSION.bin", "offset": 65536 }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Using esp-web-tools we can now flash an ESP32 from a supported browser.

To support this properly:
* add the 4 binary image artifacts required to fully flash an ESP32
* add an esp-web-tools manifest generator and workflow step
* add an index page to drive esp-web-tools
* add a release step to gather and deploy _all_ the pieces automatically

On next major release (v2.0.0), a website will be deployed, the final URL will be announced at that time.