### PR TITLE
Set BLE power after connection is established.

### DIFF
--- a/lib/furble/Camera.cpp
+++ b/lib/furble/Camera.cpp
@@ -4,6 +4,16 @@
 
 namespace Furble {
 
+bool Camera::connect(esp_power_level_t power, progressFunc pFunc, void *pCtx) {
+  bool connected = this->connect(pFunc, pCtx);
+  if (connected) {
+    // Set BLE transmit power after connection is established.
+    NimBLEDevice::setPower(power);
+  }
+
+  return connected;
+}
+
 const char *Camera::getName(void) {
   return m_Name.c_str();
 }

--- a/lib/furble/Camera.h
+++ b/lib/furble/Camera.h
@@ -54,14 +54,9 @@ class Camera {
   } timesync_t;
 
   /**
-   * Connect to the target camera such that it is ready for shutter control.
-   *
-   * This should include connection and pairing as needed for the target
-   * device.
-   *
-   * @return true if the client is now ready for shutter control
+   * Wrapper for protected pure virtual Camera::connect().
    */
-  virtual bool connect(progressFunc pFunc = nullptr, void *pCtx = nullptr) = 0;
+  bool connect(esp_power_level_t power, progressFunc pFunc = nullptr, void *pCtx = nullptr);
 
   /**
    * Disconnect from the target.
@@ -112,6 +107,16 @@ class Camera {
   void fillSaveName(char *name);
 
  protected:
+  /**
+   * Connect to the target camera such that it is ready for shutter control.
+   *
+   * This should include connection and pairing as needed for the target
+   * device.
+   *
+   * @return true if the client is now ready for shutter control
+   */
+  virtual bool connect(progressFunc pFunc = nullptr, void *pCtx = nullptr) = 0;
+
   NimBLEAddress m_Address = NimBLEAddress("");
   NimBLEClient *m_Client = NimBLEDevice::createClient();
   std::string m_Name;

--- a/lib/furble/Furble.cpp
+++ b/lib/furble/Furble.cpp
@@ -20,9 +20,10 @@ class Scan::AdvertisedCallback: public NimBLEAdvertisedDeviceCallbacks {
   }
 };
 
-void Scan::init(scanResultCallback scanCallback) {
+void Scan::init(esp_power_level_t power, scanResultCallback scanCallback) {
   m_ScanResultCallback = scanCallback;
   NimBLEDevice::init(FURBLE_STR);
+  NimBLEDevice::setPower(power);
   NimBLEDevice::setSecurityAuth(true, true, true);
   Scan::m_Scan = NimBLEDevice::getScan();
   m_Scan->setAdvertisedDeviceCallbacks(new AdvertisedCallback());
@@ -37,9 +38,5 @@ void Scan::start(const uint32_t scanDuration) {
 
 void Scan::clear(void) {
   m_Scan->clearResults();
-}
-
-void setPower(esp_power_level_t power) {
-  NimBLEDevice::setPower(power);
 }
 }  // namespace Furble

--- a/lib/furble/Furble.h
+++ b/lib/furble/Furble.h
@@ -4,6 +4,7 @@
 #include <NimBLEAdvertisedDevice.h>
 #include <NimBLEClient.h>
 #include <Preferences.h>
+#include <esp_bt.h>
 #include <vector>
 
 #include "CameraList.h"
@@ -26,7 +27,7 @@ class Scan {
   /**
    * Initialise the BLE scanner with a callback function when a matching result is encountered.
    */
-  static void init(scanResultCallback scanCallBack);
+  static void init(esp_power_level_t power, scanResultCallback scanCallBack);
 
   /**
    * Start the scan for BLE advertisements.
@@ -47,10 +48,6 @@ class Scan {
   static scanResultCallback *m_ScanResultCallback;
 };
 
-/**
- * Set the BLE transmit power.
- */
-void setPower(esp_power_level_t power);
 }  // namespace Furble
 
 #endif

--- a/src/furble.cpp
+++ b/src/furble.cpp
@@ -159,7 +159,7 @@ uint16_t disconnectDetect(void *private_data) {
   String header = ez.header.title();
 
   ezProgressBar progress_bar(FURBLE_STR, "Reconnecting ...", "");
-  if (camera->connect(&update_progress_bar, &progress_bar)) {
+  if (camera->connect(settings_load_esp_tx_power(), &update_progress_bar, &progress_bar)) {
     ez.screen.clear();
     ez.header.show(header);
     ez.buttons.show(buttons);
@@ -223,7 +223,7 @@ static void menu_connect(bool save) {
   furble_gps_update_geodata(fctx.camera);
 
   ezProgressBar progress_bar(FURBLE_STR, "Connecting ...", "");
-  if (fctx.camera->connect(&update_progress_bar, &progress_bar)) {
+  if (fctx.camera->connect(settings_load_esp_tx_power(), &update_progress_bar, &progress_bar)) {
     if (save) {
       Furble::CameraList::save(fctx.camera);
     }
@@ -296,11 +296,7 @@ void setup() {
   ez.begin();
   furble_gps_init();
 
-  Furble::Scan::init(onScanResult);
-
-  // Set BLE transmit power
-  esp_power_level_t esp_power = settings_load_esp_tx_power();
-  Furble::setPower(esp_power);
+  Furble::Scan::init(settings_load_esp_tx_power(), onScanResult);
 }
 
 void loop() {


### PR DESCRIPTION
As per the ESP32 docs, set the BLE power _after_ we have established the connection.
Whilst here, refactor the handling so 'Scan::init()' sets the power before setup and 'Camera::connect()' sets the power after success.