### PR TITLE
Add unique ID to connection parameter.

### DIFF
--- a/lib/furble/Camera.cpp
+++ b/lib/furble/Camera.cpp
@@ -28,25 +28,6 @@ void Camera::updateProgress(progressFunc pFunc, void *ctx, float value) {
   }
 }
 
-/**
- * Generate a 32-bit PRNG.
- */
-static uint32_t xorshift(uint32_t x) {
-  /* Algorithm "xor" from p. 4 of Marsaglia, "Xorshift RNGs" */
-  x ^= x << 13;
-  x ^= x << 17;
-  x ^= x << 5;
-  return x;
-}
-
-void Camera::getUUID128(uuid128_t *uuid) {
-  uint32_t chip_id = (uint32_t)ESP.getEfuseMac();
-  for (size_t i = 0; i < UUID128_AS_32_LEN; i++) {
-    chip_id = xorshift(chip_id);
-    uuid->uint32[i] = chip_id;
-  }
-}
-
 bool Camera::isConnected(void) {
   return m_Client->isConnected();
 }

--- a/lib/furble/Camera.h
+++ b/lib/furble/Camera.h
@@ -9,9 +9,6 @@
 
 #define MAX_NAME (64)
 
-#define UUID128_LEN (16)
-#define UUID128_AS_32_LEN (UUID128_LEN / sizeof(uint32_t))
-
 // Progress update function
 typedef void(progressFunc(void *, float));
 
@@ -22,16 +19,6 @@ namespace Furble {
  */
 class Camera {
  public:
-  /**
-   * UUID type.
-   */
-  typedef struct _uuid128_t {
-    union {
-      uint32_t uint32[UUID128_AS_32_LEN];
-      uint8_t uint8[UUID128_LEN];
-    };
-  } uuid128_t;
-
   /**
    * GPS data type.
    */
@@ -98,11 +85,6 @@ class Camera {
   bool isConnected(void);
 
   const char *getName(void);
-
-  /**
-   * Generate a device consistent 128-bit UUID.
-   */
-  static void getUUID128(uuid128_t *uuid);
 
   void fillSaveName(char *name);
 

--- a/lib/furble/CanonEOS.h
+++ b/lib/furble/CanonEOS.h
@@ -66,6 +66,11 @@ class CanonEOS: public Camera {
   bool serialise(void *buffer, size_t bytes);
 
   uuid128_t m_Uuid;
+
+ private:
+  volatile uint8_t m_PairResult = 0x00;
+
+  void pairCallback(NimBLERemoteCharacteristic *, uint8_t *, size_t, bool);
 };
 
 }  // namespace Furble

--- a/lib/furble/CanonEOS.h
+++ b/lib/furble/CanonEOS.h
@@ -2,6 +2,7 @@
 #define CANONEOS_H
 
 #include "Camera.h"
+#include "Device.h"
 
 namespace Furble {
 /**
@@ -15,10 +16,10 @@ class CanonEOS: public Camera {
 
  protected:
   typedef struct _eos_t {
-    char name[MAX_NAME]; /** Human readable device name. */
-    uint64_t address;    /** Device MAC address. */
-    uint8_t type;        /** Address type. */
-    uuid128_t uuid;      /** Our UUID. */
+    char name[MAX_NAME];    /** Human readable device name. */
+    uint64_t address;       /** Device MAC address. */
+    uint8_t type;           /** Address type. */
+    Device::uuid128_t uuid; /** Our UUID. */
   } eos_t;
 
   const char *CANON_EOS_SVC_IDEN_UUID = "00010000-0000-1000-0000-d8492fffa821";
@@ -65,7 +66,7 @@ class CanonEOS: public Camera {
   size_t getSerialisedBytes(void);
   bool serialise(void *buffer, size_t bytes);
 
-  uuid128_t m_Uuid;
+  Device::uuid128_t m_Uuid;
 
  private:
   volatile uint8_t m_PairResult = 0x00;

--- a/lib/furble/CanonEOSM6.cpp
+++ b/lib/furble/CanonEOSM6.cpp
@@ -8,12 +8,6 @@
 
 namespace Furble {
 
-CanonEOSM6::CanonEOSM6(const void *data, size_t len) : CanonEOS(data, len) {}
-
-CanonEOSM6::CanonEOSM6(NimBLEAdvertisedDevice *pDevice) : CanonEOS(pDevice) {}
-
-CanonEOSM6::~CanonEOSM6(void) {}
-
 const size_t CANON_EOS_M6_ADV_DATA_LEN = 21;
 const uint8_t CANON_EOS_M6_ID_0 = 0xa9;
 const uint8_t CANON_EOS_M6_ID_1 = 0x01;

--- a/lib/furble/CanonEOSM6.h
+++ b/lib/furble/CanonEOSM6.h
@@ -9,9 +9,8 @@ namespace Furble {
  */
 class CanonEOSM6: public CanonEOS {
  public:
-  CanonEOSM6(const void *data, size_t len);
-  CanonEOSM6(NimBLEAdvertisedDevice *pDevice);
-  ~CanonEOSM6(void);
+  CanonEOSM6(const void *data, size_t len) : CanonEOS(data, len){};
+  CanonEOSM6(NimBLEAdvertisedDevice *pDevice) : CanonEOS(pDevice){};
 
   /**
    * Determine if the advertised BLE device is a Canon EOS M6.

--- a/lib/furble/CanonEOSRP.cpp
+++ b/lib/furble/CanonEOSRP.cpp
@@ -8,12 +8,6 @@
 
 namespace Furble {
 
-CanonEOSRP::CanonEOSRP(const void *data, size_t len) : CanonEOS(data, len) {}
-
-CanonEOSRP::CanonEOSRP(NimBLEAdvertisedDevice *pDevice) : CanonEOS(pDevice) {}
-
-CanonEOSRP::~CanonEOSRP(void) {}
-
 const size_t CANON_EOS_RP_ADV_DATA_LEN = 8;
 const uint8_t CANON_EOS_RP_ID_0 = 0xa9;
 const uint8_t CANON_EOS_RP_ID_1 = 0x01;

--- a/lib/furble/CanonEOSRP.h
+++ b/lib/furble/CanonEOSRP.h
@@ -9,9 +9,8 @@ namespace Furble {
  */
 class CanonEOSRP: public CanonEOS {
  public:
-  CanonEOSRP(const void *data, size_t len);
-  CanonEOSRP(NimBLEAdvertisedDevice *pDevice);
-  ~CanonEOSRP(void);
+  CanonEOSRP(const void *data, size_t len) : CanonEOS(data, len){};
+  CanonEOSRP(NimBLEAdvertisedDevice *pDevice) : CanonEOS(pDevice){};
 
   /**
    * Determine if the advertised BLE device is a Canon EOS RP.

--- a/lib/furble/Device.cpp
+++ b/lib/furble/Device.cpp
@@ -1,0 +1,41 @@
+#include <Esp.h>
+
+#include "Device.h"
+#include "FurbleTypes.h"
+
+namespace Furble {
+
+Device::uuid128_t Device::g_Uuid;
+char Device::g_StringID[DEVICE_ID_STR_MAX];
+
+/**
+ * Generate a 32-bit PRNG.
+ */
+static uint32_t xorshift(uint32_t x) {
+  /* Algorithm "xor" from p. 4 of Marsaglia, "Xorshift RNGs" */
+  x ^= x << 13;
+  x ^= x << 17;
+  x ^= x << 5;
+  return x;
+}
+
+void Device::init(void) {
+  uint32_t chip_id = (uint32_t)ESP.getEfuseMac();
+  for (size_t i = 0; i < UUID128_AS_32_LEN; i++) {
+    chip_id = xorshift(chip_id);
+    g_Uuid.uint32[i] = chip_id;
+  }
+
+  // truncate ID to 5 hex characters (arbitrary, just make it 'nice' to read)
+  snprintf(g_StringID, DEVICE_ID_STR_MAX, "%s-%05x", FURBLE_STR, g_Uuid.uint32[0] & 0xFFFFF);
+}
+
+void Device::getUUID128(uuid128_t *uuid) {
+  *uuid = g_Uuid;
+}
+
+const char *Device::getStringID(void) {
+  return g_StringID;
+}
+
+}  // namespace Furble

--- a/lib/furble/Device.h
+++ b/lib/furble/Device.h
@@ -1,0 +1,45 @@
+#ifndef DEVICE_H
+#define DEVICE_H
+
+#include <cstdint>
+
+#define DEVICE_ID_STR_MAX (16)
+#define UUID128_LEN (16)
+#define UUID128_AS_32_LEN (UUID128_LEN / sizeof(uint32_t))
+
+namespace Furble {
+
+class Device {
+ public:
+  /**
+   * UUID type.
+   */
+  typedef struct _uuid128_t {
+    union {
+      uint32_t uint32[UUID128_AS_32_LEN];
+      uint8_t uint8[UUID128_LEN];
+    };
+  } uuid128_t;
+
+  /**
+   * Initialise the device.
+   */
+  static void init(void);
+
+  /**
+   * Return a device consistent 128-bit UUID.
+   */
+  static void getUUID128(uuid128_t *uuid);
+
+  /**
+   * Return pseudo-unique identifier string of this device.
+   */
+  static const char *getStringID(void);
+
+ private:
+  static uuid128_t g_Uuid;
+  static char g_StringID[DEVICE_ID_STR_MAX];
+};
+}  // namespace Furble
+
+#endif

--- a/lib/furble/Fujifilm.cpp
+++ b/lib/furble/Fujifilm.cpp
@@ -93,7 +93,7 @@ Fujifilm::Fujifilm(const void *data, size_t len) {
   if (len != sizeof(fujifilm_t))
     throw;
 
-  const fujifilm_t *fujifilm = (fujifilm_t *)data;
+  const fujifilm_t *fujifilm = static_cast<const fujifilm_t *>(data);
   m_Name = std::string(fujifilm->name);
   m_Address = NimBLEAddress(fujifilm->address, fujifilm->type);
   memcpy(m_Token, fujifilm->token, FUJIFILM_TOKEN_LEN);
@@ -323,7 +323,7 @@ bool Fujifilm::serialise(void *buffer, size_t bytes) {
   if (bytes != sizeof(fujifilm_t)) {
     return false;
   }
-  fujifilm_t *x = (fujifilm_t *)buffer;
+  fujifilm_t *x = static_cast<fujifilm_t *>(buffer);
   strncpy(x->name, m_Name.c_str(), 64);
   x->address = (uint64_t)m_Address;
   x->type = m_Address.getType();

--- a/lib/furble/Fujifilm.cpp
+++ b/lib/furble/Fujifilm.cpp
@@ -4,6 +4,7 @@
 #include <NimBLERemoteCharacteristic.h>
 #include <NimBLERemoteService.h>
 
+#include "Device.h"
 #include "Fujifilm.h"
 
 typedef struct _fujifilm_t {
@@ -178,7 +179,7 @@ bool Fujifilm::connect(progressFunc pFunc, void *pCtx) {
   pChr = pSvc->getCharacteristic(FUJIFILM_CHR_IDEN_UUID);
   if (!pChr->canWrite())
     return false;
-  if (!pChr->writeValue(FURBLE_STR, true))
+  if (!pChr->writeValue(Device::getStringID(), true))
     return false;
   Serial.println("Identified!");
   updateProgress(pFunc, pCtx, 40.0f);

--- a/lib/furble/Furble.cpp
+++ b/lib/furble/Furble.cpp
@@ -1,6 +1,7 @@
 #include <NimBLEAdvertisedDevice.h>
 #include <NimBLEDevice.h>
 
+#include "Device.h"
 #include "Furble.h"
 
 namespace Furble {
@@ -22,7 +23,7 @@ class Scan::AdvertisedCallback: public NimBLEAdvertisedDeviceCallbacks {
 
 void Scan::init(esp_power_level_t power, scanResultCallback scanCallback) {
   m_ScanResultCallback = scanCallback;
-  NimBLEDevice::init(FURBLE_STR);
+  NimBLEDevice::init(Device::getStringID());
   NimBLEDevice::setPower(power);
   NimBLEDevice::setSecurityAuth(true, true, true);
   Scan::m_Scan = NimBLEDevice::getScan();

--- a/src/furble.cpp
+++ b/src/furble.cpp
@@ -14,7 +14,7 @@ const uint32_t SCAN_DURATION = 10;
  * Progress bar update function.
  */
 void update_progress_bar(void *ctx, float value) {
-  ezProgressBar *progress_bar = (ezProgressBar *)ctx;
+  ezProgressBar *progress_bar = static_cast<ezProgressBar *>(ctx);
   progress_bar->value(value);
 }
 
@@ -149,7 +149,7 @@ static void remote_control(FurbleCtx *fctx) {
 }
 
 uint16_t disconnectDetect(void *private_data) {
-  FurbleCtx *fctx = (FurbleCtx *)private_data;
+  FurbleCtx *fctx = static_cast<FurbleCtx *>(private_data);
   Furble::Camera *camera = fctx->camera;
 
   if (camera->isConnected())

--- a/src/furble.cpp
+++ b/src/furble.cpp
@@ -1,3 +1,4 @@
+#include <Device.h>
 #include <Furble.h>
 #include <M5ez.h>
 
@@ -34,7 +35,8 @@ static void about(void) {
     version = "unknown";
   }
 
-  ez.msgBox(FURBLE_STR " - About", "Version: " + version, "Back", true);
+  ez.msgBox(FURBLE_STR " - About", "Version: " + version + "|ID: " + Furble::Device::getStringID(),
+            "Back", true);
 }
 
 static void show_shutter_control(bool shutter_locked, unsigned long lock_start_ms) {
@@ -294,6 +296,7 @@ void setup() {
 #include <themes/mono_furble.h>
 
   ez.begin();
+  Furble::Device::init();
   furble_gps_init();
 
   Furble::Scan::init(settings_load_esp_tx_power(), onScanResult);


### PR DESCRIPTION
Minor C++ refactor.
    
    Use static_cast where possible.
    Migrate to class function binding rather than static.
    Default to parent class constructor using initialisers.

Add unique ID to connection parameter.
    
    When connecting, append a subset of the ESP32 'unique' identifier, which
    is derived from the device MAC address.
