### PR TITLE
85 disable connect and delete saved if there are no connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ More details are on the wiki: [PlatformIO](https://github.com/gkoh/furble/wiki/L
 ## Usage
 
 The top level menu has the following entries:
-- `Connect`
+- `Connect` (if there are saved connections)
 - `Scan`
-- `Delete Saved`
+- `Delete Saved` (if there are saved connections)
 - `Settings`
 - `Power Off`
 

--- a/lib/furble/CameraList.cpp
+++ b/lib/furble/CameraList.cpp
@@ -26,7 +26,11 @@ typedef struct {
 } index_entry_t;
 
 static void save_index(std::vector<index_entry_t> &index) {
-  m_Prefs.putBytes(FURBLE_PREF_INDEX, index.data(), sizeof(index[0]) * index.size());
+  if (index.size() > 0) {
+    m_Prefs.putBytes(FURBLE_PREF_INDEX, index.data(), sizeof(index[0]) * index.size());
+  } else {
+    m_Prefs.remove(FURBLE_PREF_INDEX);
+  }
 }
 
 static std::vector<index_entry_t> load_index(void) {
@@ -147,6 +151,14 @@ void CameraList::load(void) {
     }
   }
   m_Prefs.end();
+}
+
+size_t CameraList::getSaveCount(void) {
+  m_Prefs.begin(FURBLE_STR, false);
+  auto index = load_index();
+  m_Prefs.end();
+
+  return index.size();
 }
 
 void CameraList::match(NimBLEAdvertisedDevice *pDevice) {

--- a/lib/furble/CameraList.h
+++ b/lib/furble/CameraList.h
@@ -25,6 +25,11 @@ class CameraList {
   static void load(void);
 
   /**
+   * Get number of saved connections.
+   */
+  static size_t getSaveCount(void);
+
+  /**
    * Add matching devices to the list.
    */
   static void match(NimBLEAdvertisedDevice *pDevice);

--- a/src/furble.cpp
+++ b/src/furble.cpp
@@ -303,13 +303,22 @@ void setup() {
 }
 
 void loop() {
+  size_t save_count = Furble::CameraList::getSaveCount();
+
   ezMenu mainmenu(FURBLE_STR);
   mainmenu.buttons("OK#down");
-  mainmenu.addItem("Connect", do_saved);
+  if (save_count > 0) {
+    mainmenu.addItem("Connect", do_saved);
+  }
   mainmenu.addItem("Scan", do_scan);
-  mainmenu.addItem("Delete Saved", menu_delete);
+  if (save_count > 0) {
+    mainmenu.addItem("Delete Saved", menu_delete);
+  }
   mainmenu.addItem("Settings", menu_settings);
   mainmenu.addItem("Power Off", mainmenu_poweroff);
   mainmenu.downOnLast("first");
-  mainmenu.run();
+
+  do {
+    mainmenu.runOnce();
+  } while (Furble::CameraList::getSaveCount() == save_count);
 }


### PR DESCRIPTION
 Disable 'Connect' and 'Delete Saved' if there are no connections.
    
Also, fix a bug with deleting down to zero connections by removing the
preference entry.
