### PR TITLE
Migrate from pages-action to wrangler-action for release deployment.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,4 +126,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy deploy --project-name=furble-web-installer --branch=${{ github.event.release.prerelease == false && 'main' || github.ref_name }}
+          command: pages deploy deploy --project-name=furble-web-installer --branch=${{ github.event.release.prerelease && 'HEAD' || 'main' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,11 +120,11 @@ jobs:
           mv furble-*.bin deploy/firmware
 
       - name: Publish
-        uses: cloudflare/pages-action@1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: furble-web-installer
-          directory: deploy
+          workingDirectory: deploy
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          branch: main
+          branch: ${{ github.event.release.prerelease && github.ref_name || 'main' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,4 +126,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy deploy --project-name=furble-web-installer --event=${{ github.event.release.prerelease == true }} --branch=${{ !github.event.release.prerelease && 'main' || 'HEAD' }}
+          command: pages deploy deploy --project-name=furble-web-installer --event=${{ github.event.release.prerelease == 'true' }} --branch=${{ !github.event.release.prerelease && 'main' || 'HEAD' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
             sha256sum.txt
 
   deploy:
-    needs: build
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,4 +124,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy deploy --project-name=furble-web-installer --event=${{ github.event.release.prerelease }} --branch=${{ !github.event.release.prerelease && 'main' || 'HEAD' }}
+          command: pages deploy deploy --project-name=furble-web-installer --branch=${{ !github.event.release.prerelease && 'main' || 'HEAD' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,4 +126,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy deploy --project-name=furble-web-installer --branch=${{ github.event.release.prerelease && 'HEAD' || 'main' }}
+          command: pages deploy deploy --project-name=furble-web-installer --event=${{ github.event.release.prerelease }} --branch=${{ !github.event.release.prerelease && 'main' || 'HEAD' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release furble
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 env:
   FURBLE_VERSION: ${{ github.ref_name }}+${{ github.run_attempt }}
@@ -89,9 +88,8 @@ jobs:
           sha256sum furble-*.bin > sha256sum.txt
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
           files: |
             furble-*.bin
             manifest_*.json
@@ -126,4 +124,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy deploy --project-name=furble-web-installer --event=${{ github.event.release.prerelease == 'true' }} --branch=${{ !github.event.release.prerelease && 'main' || 'HEAD' }}
+          command: pages deploy deploy --project-name=furble-web-installer --event=${{ github.event.release.prerelease }} --branch=${{ !github.event.release.prerelease && 'main' || 'HEAD' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,4 +126,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy deploy --project-name=furble-web-installer --event=${{ github.event.release.prerelease }} --branch=${{ !github.event.release.prerelease && 'main' || 'HEAD' }}
+          command: pages deploy deploy --project-name=furble-web-installer --event=${{ github.event.release.prerelease == true }} --branch=${{ !github.event.release.prerelease && 'main' || 'HEAD' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,4 +126,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy deploy --project-name=furble-web-installer --branch=${{ github.event.release.prerelease && github.ref_name || 'main' }}
+          command: pages deploy deploy --project-name=furble-web-installer --branch=${{ github.event.release.prerelease == false && 'main' || github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: furble-web-installer
-          workingDirectory: deploy
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.event.release.prerelease && github.ref_name || 'main' }}
+          command: pages deploy deploy --project-name=furble-web-installer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,8 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    name: Generate release artifacts
+
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -124,4 +126,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy deploy --project-name=furble-web-installer
+          command: pages deploy deploy --project-name=furble-web-installer --branch=${{ github.event.release.prerelease && github.ref_name || 'main' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
       contents: write
 
     env:
-      FIRMWARE_NAME: furble-${{ matrix.platform }}-${{ env.FURBLE_VERSION }}.bin
-      BOOTLOADER_NAME: furble-bootloader-${{ matrix.platform }}-${{ env.FURBLE_VERSION }}.bin
-      PARTITIONS_NAME: furble-partitions-${{ matrix.platform }}-${{ env.FURBLE_VERSION }}.bin
-      BOOT_APP0_NAME: furble-boot-app0-${{ matrix.platform }}-${{ env.FURBLE_VERSION }}.bin
+      FIRMWARE_NAME: furble-${{ matrix.platform }}-${{ github.ref_name }}+${{ github.run_attempt }}.bin
+      BOOTLOADER_NAME: furble-bootloader-${{ matrix.platform }}-${{ github.ref_name }}+${{ github.run_attempt }}.bin
+      PARTITIONS_NAME: furble-partitions-${{ matrix.platform }}-${{ github.ref_name }}+${{ github.run_attempt }}.bin
+      BOOT_APP0_NAME: furble-boot-app0-${{ matrix.platform }}-${{ github.ref_name }}+${{ github.run_attempt }}.bin
 
     steps:
       - uses: actions/checkout@v4
@@ -124,4 +124,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy deploy --project-name=furble-web-installer --branch=${{ !github.event.release.prerelease && 'main' || 'HEAD' }}
+          command: pages deploy deploy --project-name=furble-web-installer --event=${{ github.event.release.prerelease }} --branch=${{ !github.event.release.prerelease && 'main' || 'HEAD' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
       contents: write
 
     env:
-      FIRMWARE_NAME: furble-${{ matrix.platform }}-${{ github.ref_name }}+${{ github.run_attempt }}.bin
-      BOOTLOADER_NAME: furble-bootloader-${{ matrix.platform }}-${{ github.ref_name }}+${{ github.run_attempt }}.bin
-      PARTITIONS_NAME: furble-partitions-${{ matrix.platform }}-${{ github.ref_name }}+${{ github.run_attempt }}.bin
-      BOOT_APP0_NAME: furble-boot-app0-${{ matrix.platform }}-${{ github.ref_name }}+${{ github.run_attempt }}.bin
+      FIRMWARE_NAME: furble-${{ matrix.platform }}-${{ env.FURBLE_VERSION }}.bin
+      BOOTLOADER_NAME: furble-bootloader-${{ matrix.platform }}-${{ env.FURBLE_VERSION }}.bin
+      PARTITIONS_NAME: furble-partitions-${{ matrix.platform }}-${{ env.FURBLE_VERSION }}.bin
+      BOOT_APP0_NAME: furble-boot-app0-${{ matrix.platform }}-${{ env.FURBLE_VERSION }}.bin
 
     steps:
       - uses: actions/checkout@v4
@@ -124,4 +124,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy deploy --project-name=furble-web-installer --event=${{ github.event.release.prerelease }} --branch=${{ !github.event.release.prerelease && 'main' || 'HEAD' }}
+          command: pages deploy deploy --project-name=furble-web-installer --branch=${{ !github.event.release.prerelease && 'main' || 'HEAD' }}


### PR DESCRIPTION
pages-action will be deprecated, migrate to the replacement wrangler-action.
Change release trigger to the publish event.
Bump action-gh-release to v2.