### PR TITLE
Fix M5stickC Plus2 backlight blinking when inactivity timeout

### DIFF
--- a/lib/M5ez/src/M5ez.cpp
+++ b/lib/M5ez/src/M5ez.cpp
@@ -907,7 +907,7 @@ uint16_t ezBacklight::loop(void *private_data) {
   if (!_backlight_off && _inactivity) {
     if (millis() > _last_activity + 30000 * _inactivity) {
       _backlight_off = true;
-      M5.Display.setBrightness(64);
+      M5.Display.setBrightness(0);
       changeCpuPower(true);
       while (true) {
         if (M5.BtnA.wasClicked() || M5.BtnB.wasClicked())


### PR DESCRIPTION
First of all, thank you for your project. I'm using it very well.
But backlight doesn't turn off on the m5stickc plus2.
so set Brightness to 0.

https://github.com/user-attachments/assets/cece9d6e-220e-4219-a836-24e37692dcb5

I've tested it and it works fine on me. But you need to check how it works on other devices.