### PR TITLE
111, 112 Backlight handling improve

### DIFF
--- a/lib/M5ez/src/M5ez.cpp
+++ b/lib/M5ez/src/M5ez.cpp
@@ -840,11 +840,11 @@ void ezBacklight::menu() {
           String b = ez.buttons.poll();
           if (b == "Adjust") {
             if (_brightness >= _MinimumBrightness && _brightness < (255 - _MinimumBrightness))
-              _brightness += (255 - _MinimumBrightness) / 8;
+              _brightness += (255 - _MinimumBrightness) / 7;
             else
-              _brightness = _MinimumBrightness + (255 - _MinimumBrightness) / 8;
+              _brightness = _MinimumBrightness;
           }
-          float p = float(_brightness) / 2.48;
+          float p = float(_brightness - _MinimumBrightness) / (255 - _MinimumBrightness) * 100;
           bl.value(p);
           M5.Display.setBrightness(_brightness);
           if (b == "Back")

--- a/lib/M5ez/src/M5ez.cpp
+++ b/lib/M5ez/src/M5ez.cpp
@@ -834,7 +834,8 @@ void ezBacklight::menu() {
   blmenu.addItem("Inactivity timeout");
   blmenu.addItem("Back");
   blmenu.downOnLast("first");
-  _Step = (_brightness - _MinimumBrightness) * (_MaxSteps) / (256 - _MinimumBrightness); // Calculate step from brightness
+  _Step = (_brightness - _MinimumBrightness) * _MaxSteps
+          / (256 - _MinimumBrightness);  // Calculate step from brightness
   while (true) {
     switch (blmenu.runOnce()) {
       case 1: {
@@ -842,13 +843,11 @@ void ezBacklight::menu() {
         while (true) {
           String b = ez.buttons.poll();
           if (b == "Adjust") {
-            if (_brightness >= _MinimumBrightness && _Step < _MaxSteps - 1)
-            {
+            if (_brightness >= _MinimumBrightness && _Step < _MaxSteps - 1) {
               _Step++;
-              _brightness = _MinimumBrightness + (_Step * (255 - _MinimumBrightness) / (_MaxSteps - 1));
-            }
-            else
-            {
+              _brightness =
+                  _MinimumBrightness + (_Step * (255 - _MinimumBrightness) / (_MaxSteps - 1));
+            } else {
               _Step = 0;
               _brightness = _MinimumBrightness;
             }

--- a/lib/M5ez/src/M5ez.cpp
+++ b/lib/M5ez/src/M5ez.cpp
@@ -794,6 +794,8 @@ uint8_t ezBacklight::_brightness;
 uint8_t ezBacklight::_inactivity;
 uint32_t ezBacklight::_last_activity;
 uint8_t ezBacklight::_MinimumBrightness;
+uint8_t ezBacklight::_Step = 0;
+uint8_t ezBacklight::_MaxSteps = 8;
 bool ezBacklight::_backlight_off = false;
 
 void ezBacklight::begin() {
@@ -832,6 +834,7 @@ void ezBacklight::menu() {
   blmenu.addItem("Inactivity timeout");
   blmenu.addItem("Back");
   blmenu.downOnLast("first");
+  _Step = (_brightness - _MinimumBrightness) * (_MaxSteps) / (256 - _MinimumBrightness); // Calculate step from brightness
   while (true) {
     switch (blmenu.runOnce()) {
       case 1: {
@@ -839,12 +842,18 @@ void ezBacklight::menu() {
         while (true) {
           String b = ez.buttons.poll();
           if (b == "Adjust") {
-            if (_brightness >= _MinimumBrightness && _brightness < (255 - _MinimumBrightness))
-              _brightness += (255 - _MinimumBrightness) / 7;
+            if (_brightness >= _MinimumBrightness && _Step < _MaxSteps - 1)
+            {
+              _Step++;
+              _brightness = _MinimumBrightness + (_Step * (255 - _MinimumBrightness) / (_MaxSteps - 1));
+            }
             else
+            {
+              _Step = 0;
               _brightness = _MinimumBrightness;
+            }
           }
-          float p = float(_brightness - _MinimumBrightness) / (255 - _MinimumBrightness) * 100;
+          float p = ((float)_Step / (_MaxSteps - 1)) * 100.0f;
           bl.value(p);
           M5.Display.setBrightness(_brightness);
           if (b == "Back")

--- a/lib/M5ez/src/M5ez.h
+++ b/lib/M5ez/src/M5ez.h
@@ -509,6 +509,7 @@ class ezBacklight {
   static uint8_t _brightness;
   static uint8_t _inactivity;
   static uint32_t _last_activity;
+  static uint8_t _MinimumBrightness;
   static bool _backlight_off;
   //
 };

--- a/lib/M5ez/src/M5ez.h
+++ b/lib/M5ez/src/M5ez.h
@@ -510,6 +510,8 @@ class ezBacklight {
   static uint8_t _inactivity;
   static uint32_t _last_activity;
   static uint8_t _MinimumBrightness;
+  static uint8_t _Step;
+  static uint8_t _MaxSteps;
   static bool _backlight_off;
   //
 };


### PR DESCRIPTION
I made the lowest brightness of the backlight change depending on the device, and also modified the brightness slider to have 8 levels.
#111 Backlight timeout brightness is hardcoded and too high and #112 Backlight menu slider needs tweaking.

The name of the board is referenced here.( https://docs.m5stack.com/en/arduino/m5unified/m5unified_appendix )