### PR TITLE
Adjust connection parameters to increase communication range.

### DIFF
--- a/lib/furble/Camera.cpp
+++ b/lib/furble/Camera.cpp
@@ -5,6 +5,8 @@
 namespace Furble {
 
 bool Camera::connect(esp_power_level_t power, progressFunc pFunc, void *pCtx) {
+  // try extending range by adjusting connection parameters
+  m_Client->updateConnParams(m_MinInterval, m_MaxInterval, m_Latency, m_Timeout);
   bool connected = this->connect(pFunc, pCtx);
   if (connected) {
     // Set BLE transmit power after connection is established.

--- a/lib/furble/Camera.h
+++ b/lib/furble/Camera.h
@@ -106,6 +106,12 @@ class Camera {
   void updateProgress(progressFunc pFunc, void *ctx, float value);
 
  private:
+  const uint16_t m_MinInterval = BLE_GAP_INITIAL_CONN_ITVL_MIN;
+  const uint16_t m_MaxInterval = BLE_GAP_INITIAL_CONN_ITVL_MAX;
+  // allow a packet to skip
+  const uint16_t m_Latency = 1;
+  // double the disconnect timeout
+  const uint16_t m_Timeout = (2 * BLE_GAP_INITIAL_SUPERVISION_TIMEOUT);
 };
 }  // namespace Furble
 


### PR DESCRIPTION
Increase the latency to 1 (from default 0).
Double the supervision timeout (so disconnection isn't as sensitive).