### PR TITLE
M5ez refactor

### DIFF
--- a/include/spinner.h
+++ b/include/spinner.h
@@ -16,7 +16,7 @@ struct __attribute__((packed)) SpinValue {
 
 void spinner_modify_value(const char *title, bool preset, SpinValue *sv);
 
-String sv2str(SpinValue *sv);
+std::string sv2str(SpinValue *sv);
 unsigned long sv2ms(SpinValue *sv);
 void ms2hms(unsigned long ms, unsigned int *h, unsigned int *m, unsigned int *s);
 

--- a/lib/M5ez/src/M5ez.cpp
+++ b/lib/M5ez/src/M5ez.cpp
@@ -2,32 +2,8 @@
 
 #include <Preferences.h>
 
-#ifdef M5EZ_WIFI
-#include <WiFi.h>
-extern "C" {
-#include "esp_wifi.h"
-#include "esp_wps.h"
-}
-#include <Update.h>
-#include <WiFiClientSecure.h>  // For ez.update
-#endif                         // M5EZ_WIFI
-
-#ifdef M5EZ_BATTERY
-#endif
-
-#ifdef M5EZ_CLOCK
-#include <ezTime.h>
-#endif
-
-#ifdef M5EZ_BLE
-#include <BLEAdvertisedDevice.h>
-#include <BLEDevice.h>
-#include <BLEScan.h>
-#include <BLEUtils.h>
-#endif
-
-#include <Wire.h>
 #include <algorithm>
+#include <string>
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -44,7 +20,7 @@ void ezTheme::begin() {
   ez.theme = &ez.themes[0];
   Preferences prefs;
   prefs.begin("M5ez", true);  // read-only
-  select(prefs.getString("theme", ""));
+  select(prefs.getString("theme", "").c_str());
   prefs.end();
 }
 
@@ -52,7 +28,7 @@ void ezTheme::add() {
   ez.themes.push_back(*this);
 }
 
-bool ezTheme::select(String name) {
+bool ezTheme::select(std::string name) {
   for (uint8_t n = 0; n < ez.themes.size(); n++) {
     if (ez.themes[n].name == name) {
       ez.theme = &ez.themes[n];
@@ -63,10 +39,10 @@ bool ezTheme::select(String name) {
 }
 
 void ezTheme::menu() {
-  String orig_name = ez.theme->name;
+  std::string orig_name = ez.theme->name;
   ezMenu thememenu("Theme chooser");
   thememenu.txtSmall();
-  thememenu.buttons("OK#down");
+  thememenu.buttons({"OK", "down"});
   thememenu.downOnLast("first");
 
   for (uint8_t n = 0; n < ez.themes.size(); n++) {
@@ -83,7 +59,7 @@ void ezTheme::menu() {
   if (ez.theme->name != orig_name) {
     Preferences prefs;
     prefs.begin("M5ez");
-    prefs.putString("theme", ez.theme->name);
+    prefs.putString("theme", ez.theme->name.c_str());
     prefs.end();
   }
   return;
@@ -130,7 +106,7 @@ void ezScreen::clear(uint16_t color) {
 
 std::vector<header_widget_t> ezHeader::_widgets;
 bool ezHeader::_shown;
-String ezHeader::_title;
+std::string ezHeader::_title;
 
 void ezHeader::begin() {
   _widgets.clear();
@@ -165,7 +141,7 @@ void ezHeader::_recalculate() {
 }
 
 void ezHeader::insert(uint8_t position,
-                      String name,
+                      std::string name,
                       uint16_t width,
                       void (*function)(uint16_t x, uint16_t w),
                       bool leftover /* = false */) {
@@ -187,7 +163,7 @@ void ezHeader::insert(uint8_t position,
   _recalculate();
 }
 
-void ezHeader::remove(String name) {
+void ezHeader::remove(std::string name) {
   for (uint8_t n = 0; n < _widgets.size(); n++) {
     if (_widgets[n].name == name) {
       _widgets.erase(_widgets.begin() + n);
@@ -196,7 +172,7 @@ void ezHeader::remove(String name) {
   }
 }
 
-uint8_t ezHeader::position(String name) {
+uint8_t ezHeader::position(std::string name) {
   for (uint8_t n = 0; n < _widgets.size(); n++) {
     if (_widgets[n].name == name)
       return n;
@@ -204,7 +180,7 @@ uint8_t ezHeader::position(String name) {
   return 0;
 }
 
-void ezHeader::show(String t /* = "" */) {
+void ezHeader::show(std::string t /* = "" */) {
   _shown = true;
   if (t != "")
     _title = t;  // only change title if provided
@@ -216,7 +192,7 @@ void ezHeader::show(String t /* = "" */) {
   ez.canvas.top(ez.theme->header_height);
 }
 
-void ezHeader::draw(String name) {
+void ezHeader::draw(std::string name) {
   if (!_shown)
     return;
   for (uint8_t n = 0; n < _widgets.size(); n++) {
@@ -237,15 +213,11 @@ bool ezHeader::shown() {
   return _shown;
 }
 
-String ezHeader::title() {
-  //	if (_shown)	{
+std::string ezHeader::title() {
   return _title;
-  //	} else {
-  //		return "";
-  //	}
 }
 
-void ezHeader::title(String t) {
+void ezHeader::title(std::string t) {
   _title = t;
   if (_shown)
     draw("title");
@@ -256,7 +228,7 @@ void ezHeader::_drawTitle(uint16_t x, uint16_t w) {
   M5.Lcd.setTextDatum(TL_DATUM);
   M5.Lcd.setTextColor(ez.theme->header_fgcolor);
   ez.setFont(ez.theme->header_font);
-  M5.Lcd.drawString(ez.clipString(_title, w - ez.theme->header_hmargin),
+  M5.Lcd.drawString(ez.clipString(_title, w - ez.theme->header_hmargin).c_str(),
                     x + ez.theme->header_hmargin, ez.theme->header_tmargin);
 }
 
@@ -399,22 +371,18 @@ void ezCanvas::bottom(uint8_t newbottom) {
 }
 
 size_t ezCanvas::write(uint8_t c) {
-  String tmp = String((char)c);
-  _print(tmp);
+  _print(std::string(c, 1));
   return 1;
 }
 
 size_t ezCanvas::write(const char *str) {
-  String tmp = String(str);
+  std::string tmp = std::string(str);
   _print(tmp);
-  return sizeof(str);
+  return tmp.size();
 }
 
 size_t ezCanvas::write(const uint8_t *buffer, size_t size) {
-  String tmp;
-  tmp.reserve(size);
-  for (uint16_t n = 0; n < size; n++)
-    tmp += (char)*(buffer + n);
+  std::string tmp = std::string((const char *)buffer, size);
   _print(tmp);
   return size;
 }
@@ -439,7 +407,7 @@ uint16_t ezCanvas::loop(void *private_data) {
           ez.setFont(_printed[n].font);
         if (_printed[n].color != _color)
           M5.Lcd.setTextColor(_printed[n].color);
-        M5.Lcd.drawString(_printed[n].text, _printed[n].x, _printed[n].y);
+        M5.Lcd.drawString(_printed[n].text.c_str(), _printed[n].x, _printed[n].y);
       }
     }
     _y -= scroll_by;
@@ -458,7 +426,7 @@ uint16_t ezCanvas::loop(void *private_data) {
   return 10;
 }
 
-void ezCanvas::_print(String text) {
+void ezCanvas::_print(std::string text) {
   ez.setFont(_font);
   M5.Lcd.setTextDatum(TL_DATUM);
   M5.Lcd.setTextColor(_color, ez.theme->background);
@@ -469,25 +437,25 @@ void ezCanvas::_print(String text) {
     if (!_next_scroll)
       _next_scroll = millis() + 200;
   }
-  int16_t crlf = text.indexOf("\r\n");
-  String remainder = "";
-  if (crlf != -1) {
-    remainder = text.substring(crlf + 2);
-    text = text.substring(0, crlf);
+  auto crlf = text.find("\r\n");
+  std::string remainder = "";
+  if (crlf != std::string::npos) {
+    remainder = text.substr(crlf + 2);
+    text = text.substr(0, crlf);
   }
-  if (_x + M5.Lcd.textWidth(text) <= _right) {
+  if (_x + M5.Lcd.textWidth(text.c_str()) <= _right) {
     if (text != "")
       _putString(text);
   } else {
     for (uint16_t n = 0; n < text.length(); n++) {
-      if (_x + M5.Lcd.textWidth(text.substring(0, n + 1)) > _right) {
+      if (_x + M5.Lcd.textWidth(text.substr(0, n + 1).c_str()) > _right) {
         if (n) {
-          _putString(text.substring(0, n));
+          _putString(text.substr(0, n));
         }
         if (_wrap) {
           _x = _lmargin;
           _y += h;
-          _print(text.substring(n));
+          _print(text.substr(n));
         }
         break;
       }
@@ -501,7 +469,7 @@ void ezCanvas::_print(String text) {
   }
 }
 
-void ezCanvas::_putString(String text) {
+void ezCanvas::_putString(std::string text) {
   ez.setFont(_font);
   uint8_t h = ez.fontHeight();
   if (_scroll) {
@@ -514,9 +482,9 @@ void ezCanvas::_putString(String text) {
     _printed.push_back(p);
   }
   if (_y + h > _bottom) {
-    _x += M5.Lcd.textWidth(text);
+    _x += M5.Lcd.textWidth(text.c_str());
   } else {
-    _x += M5.Lcd.drawString(text, _x, _y);
+    _x += M5.Lcd.drawString(text.c_str(), _x, _y);
   }
 }
 
@@ -527,9 +495,9 @@ void ezCanvas::_putString(String text) {
 //
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-String ezButtons::_btn_a_s, ezButtons::_btn_a_l;
-String ezButtons::_btn_b_s, ezButtons::_btn_b_l;
-String ezButtons::_btn_c_s, ezButtons::_btn_c_l;
+std::string ezButtons::_btn_a;
+std::string ezButtons::_btn_b;
+std::string ezButtons::_btn_c;
 bool ezButtons::_key_release_wait;
 bool ezButtons::_lower_button_row, ezButtons::_upper_button_row;
 
@@ -537,26 +505,22 @@ void ezButtons::begin() {
   clear(false);
 }
 
-void ezButtons::show(String buttons) {
-  buttons.trim();
-  std::vector<String> buttonVector;
-  ez.chopString(buttons, "#", buttonVector, true);
-  switch (buttonVector.size()) {
+void ezButtons::show(std::vector<std::string> buttons) {
+  switch (buttons.size()) {
     case 1:
-      _drawButtons("", "", buttons, "", "", "", "", "", "");
+      _drawButtons("", buttons[0], "");
       break;
     case 2:
-      _drawButtons(buttonVector[0], "", buttonVector[1], "", "", "", "", "", "");
+      _drawButtons(buttons[0], buttons[1], "");
       break;
     case 3:
-      // Three elements, so shortpress only
-      _drawButtons(buttonVector[0], "", buttonVector[1], "", buttonVector[2], "", "", "", "");
+      _drawButtons(buttons[0], buttons[1], buttons[2]);
       break;
   }
 }
 
-String ezButtons::get() {
-  return (_btn_a_s + "#" + _btn_b_s + "#" + _btn_c_s);
+std::vector<std::string> ezButtons::get() {
+  return {_btn_a, _btn_b, _btn_c};
 }
 
 void ezButtons::clear(bool wipe /* = true */) {
@@ -564,49 +528,34 @@ void ezButtons::clear(bool wipe /* = true */) {
     M5.Lcd.fillRect(0, ez.canvas.bottom() + 1, TFT_H - ez.canvas.bottom() - 1, TFT_W,
                     ez.screen.background());
   }
-  _btn_a_s = _btn_a_l = _btn_b_s = _btn_b_l = _btn_c_s = _btn_c_l = "";
+  _btn_a = _btn_b = _btn_c = "";
   _lower_button_row = false;
   _upper_button_row = false;
   ez.canvas.bottom(TFT_H - 1);
 }
 
-void ezButtons::_drawButtons(String btn_a_s,
-                             String btn_a_l,
-                             String btn_b_s,
-                             String btn_b_l,
-                             String btn_c_s,
-                             String btn_c_l,
-                             String btn_ab,
-                             String btn_bc,
-                             String btn_ac) {
+void ezButtons::_drawButtons(std::string btn_a, std::string btn_b, std::string btn_c) {
   int16_t btnwidth = int16_t((TFT_W - 4 * ez.theme->button_gap) / 3);
 
   // See if any buttons are used on the bottom row
-  if (btn_a_s != "" || btn_a_l != "" || btn_b_s != "" || btn_b_l != "" || btn_c_s != ""
-      || btn_c_l != "") {
+  if (btn_a != "" || btn_b != "" || btn_c != "") {
     if (!_lower_button_row) {
       // If the lower button row wasn't there before, clear the area first
       M5.Lcd.fillRect(0, TFT_H - ez.theme->button_height - ez.theme->button_gap, TFT_W,
                       ez.theme->button_height + ez.theme->button_gap, ez.screen.background());
     }
     // Then draw the three buttons there. (drawButton erases single buttons if unused.)
-    if (_btn_a_s != btn_a_s || _btn_a_l != btn_a_l) {
-      _drawButton(1, ez.rightOf(btn_a_s, "|", true), ez.rightOf(btn_a_l, "|", true),
-                  ez.theme->button_gap, btnwidth);
-      _btn_a_s = btn_a_s;
-      _btn_a_l = btn_a_l;
+    if (_btn_a != btn_a) {
+      _drawButton(1, btn_a, ez.theme->button_gap, btnwidth);
+      _btn_a = btn_a;
     }
-    if (_btn_b_s != btn_b_s || _btn_b_l != btn_b_l) {
-      _drawButton(1, ez.rightOf(btn_b_s, "|", true), ez.rightOf(btn_b_l, "|", true),
-                  btnwidth + 2 * ez.theme->button_gap, btnwidth);
-      _btn_b_s = btn_b_s;
-      _btn_b_l = btn_b_l;
+    if (_btn_b != btn_b) {
+      _drawButton(1, btn_b, btnwidth + 2 * ez.theme->button_gap, btnwidth);
+      _btn_b = btn_b;
     }
-    if (_btn_c_s != btn_c_s || _btn_c_l != btn_c_l) {
-      _drawButton(1, ez.rightOf(btn_c_s, "|", true), ez.rightOf(btn_c_l, "|", true),
-                  2 * btnwidth + 3 * ez.theme->button_gap, btnwidth);
-      _btn_c_s = btn_c_s;
-      _btn_c_l = btn_c_l;
+    if (_btn_c != btn_c) {
+      _drawButton(1, btn_c, 2 * btnwidth + 3 * ez.theme->button_gap, btnwidth);
+      _btn_c = btn_c;
     }
     _lower_button_row = true;
   } else {
@@ -614,7 +563,7 @@ void ezButtons::_drawButtons(String btn_a_s,
       // If there was a lower button row before and it's now gone, clear the area
       M5.Lcd.fillRect(0, TFT_H - ez.theme->button_height - ez.theme->button_gap, TFT_W,
                       ez.theme->button_height + ez.theme->button_gap, ez.screen.background());
-      _btn_a_s = _btn_a_l = _btn_b_s = _btn_b_l = _btn_c_s = _btn_c_l = "";
+      _btn_a = _btn_b = _btn_c = "";
       _lower_button_row = false;
     }
   }
@@ -623,7 +572,7 @@ void ezButtons::_drawButtons(String btn_a_s,
   ez.canvas.bottom(TFT_H - (button_rows * (ez.theme->button_height + ez.theme->button_gap)));
 }
 
-void ezButtons::_drawButton(int16_t row, String text_s, String text_l, int16_t x, int16_t w) {
+void ezButtons::_drawButton(int16_t row, std::string text, int16_t x, int16_t w) {
   // row = 1 for lower and 2 for upper row
   int16_t y, bg_color;
   if (row == 1) {
@@ -633,24 +582,17 @@ void ezButtons::_drawButton(int16_t row, String text_s, String text_l, int16_t x
     y = TFT_H - 2 * ez.theme->button_height - ez.theme->button_gap;
     bg_color = ez.theme->button_bgcolor_t;
   }
-  if (text_s != "" || text_l != "") {
+  if (text != "") {
     ez.setFont(ez.theme->button_font);
     M5.Lcd.fillRoundRect(x, y, w, ez.theme->button_height, ez.theme->button_radius, bg_color);
-    if (text_l != "") {
-      _drawButtonString(text_s, x + ez.theme->button_hmargin, y + ez.theme->button_tmargin,
-                        ez.theme->button_fgcolor, TL_DATUM);
-    } else {
-      _drawButtonString(text_s, x + int16_t(w / 2), y + ez.theme->button_tmargin,
-                        ez.theme->button_fgcolor, TC_DATUM);
-    }
-    _drawButtonString(text_l, x + w - ez.theme->button_hmargin, y + ez.theme->button_tmargin,
-                      ez.theme->button_longcolor, TR_DATUM);
+    _drawButtonString(text, x + int16_t(w / 2), y + ez.theme->button_tmargin,
+                      ez.theme->button_fgcolor, TC_DATUM);
   } else {
     M5.Lcd.fillRect(x, y, w, ez.theme->button_height, ez.screen.background());
   }
 }
 
-void ezButtons::_drawButtonString(String text,
+void ezButtons::_drawButtonString(std::string text,
                                   int16_t x,
                                   int16_t y,
                                   uint16_t color,
@@ -676,7 +618,7 @@ void ezButtons::_drawButtonString(String text,
   } else {
     M5.Lcd.setTextColor(color);
     M5.Lcd.setTextDatum(datum);
-    M5.Lcd.drawString(text, x, y + 1);
+    M5.Lcd.drawString(text.c_str(), x, y + 1);
   }
 }
 
@@ -684,26 +626,18 @@ void ezButtons::releaseWait() {
   _key_release_wait = true;
 }
 
-String ezButtons::poll() {
-  String keystr = "";
+std::string ezButtons::poll() {
+  std::string keystr = "";
 
   ez.yield();
 
   if (!_key_release_wait) {
-    if (_btn_a_l != "" && M5.BtnA.pressedFor(ez.theme->longpress_time)) {
-      keystr = ez.leftOf(_btn_a_l, "|", true);
-      _key_release_wait = true;
-    }
-    if (_btn_a_s != "" && M5.BtnA.wasReleased()) {
-      keystr = ez.leftOf(_btn_a_s, "|", true);
+    if (_btn_a != "" && M5.BtnA.wasReleased()) {
+      keystr = _btn_a;
     }
 
-    if (_btn_b_l != "" && M5.BtnB.pressedFor(ez.theme->longpress_time)) {
-      keystr = ez.leftOf(_btn_b_l, "|", true);
-      _key_release_wait = true;
-    }
-    if (_btn_b_s != "" && M5.BtnB.wasReleased()) {
-      keystr = ez.leftOf(_btn_b_s, "|", true);
+    if (_btn_b != "" && M5.BtnB.wasReleased()) {
+      keystr = _btn_b;
     }
   }
 
@@ -720,10 +654,8 @@ String ezButtons::poll() {
   return keystr;
 }
 
-String ezButtons::wait(String buttons /* = "" */) {
-  if (buttons != "")
-    show(buttons);
-  String keystr = "";
+std::string ezButtons::wait() {
+  std::string keystr = "";
   while (keystr == "") {
     keystr = ez.buttons.poll();
   }
@@ -741,13 +673,7 @@ ezMenu ezSettings::menuObj("Settings menu");
 
 void ezSettings::begin() {
   menuObj.txtSmall();
-  menuObj.buttons("up#Back#select##down#");
-#ifdef M5EZ_WIFI
-  ez.wifi.begin();
-#endif
-#ifdef M5EZ_BLE
-  ez.ble.begin();
-#endif
+  menuObj.buttons({"up", "select", "down"});
 #ifdef M5EZ_BATTERY
   ez.battery.begin();
 #endif
@@ -757,13 +683,10 @@ void ezSettings::begin() {
 #ifdef M5EZ_BACKLIGHT
   ez.backlight.begin();
 #endif
-#ifdef M5EZ_FACES
-  ez.faces.begin();
-#endif
   if (ez.themes.size() > 1) {
-    ez.settings.menuObj.addItem("Theme chooser", ez.theme->menu);
+    ez.settings.menuObj.addItem("Theme chooser", "", ez.theme->menu);
   }
-  ez.settings.menuObj.addItem("Factory defaults", ez.settings.defaults);
+  ez.settings.menuObj.addItem("Factory defaults", "", ez.settings.defaults);
 }
 
 void ezSettings::menu() {
@@ -772,7 +695,8 @@ void ezSettings::menu() {
 
 void ezSettings::defaults() {
   if (ez.msgBox("Reset to defaults?",
-                "Are you sure you want to reset all settings to factory defaults?", "yes##no")
+                {"Are you sure you want to reset all settings to factory defaults?"},
+                {"yes", "", "no"})
       == "yes") {
     Preferences prefs;
     prefs.begin("M5ez");
@@ -800,7 +724,7 @@ bool ezBacklight::_backlight_off = false;
 
 void ezBacklight::begin() {
   ez.addEvent(ez.backlight.loop);
-  ez.settings.menuObj.addItem("Backlight settings", ez.backlight.menu);
+  ez.settings.menuObj.addItem("Backlight settings", "", ez.backlight.menu);
   Preferences prefs;
   prefs.begin("M5ez", true);  // read-only
   _brightness = prefs.getUChar("brightness", 128);
@@ -829,7 +753,7 @@ void ezBacklight::menu() {
   uint8_t start_inactivity = _inactivity;
   ezMenu blmenu("Backlight settings");
   blmenu.txtSmall();
-  blmenu.buttons("OK#down");
+  blmenu.buttons({"OK", "down"});
   blmenu.addItem("Backlight brightness");
   blmenu.addItem("Inactivity timeout");
   blmenu.addItem("Back");
@@ -839,9 +763,9 @@ void ezBacklight::menu() {
   while (true) {
     switch (blmenu.runOnce()) {
       case 1: {
-        ezProgressBar bl("Backlight brightness", "Set brightness", "Adjust#Back");
+        ezProgressBar bl("Backlight brightness", {"Set brightness"}, {"Adjust", "Back"});
         while (true) {
-          String b = ez.buttons.poll();
+          std::string b = ez.buttons.poll();
           if (b == "Adjust") {
             if (_brightness >= _MinimumBrightness && _Step < _MaxSteps - 1) {
               _Step++;
@@ -860,17 +784,17 @@ void ezBacklight::menu() {
         }
       } break;
       case 2: {
-        String disp_val;
+        std::vector<std::string> disp_val;
         while (true) {
           if (!_inactivity) {
-            disp_val = "Backlight will not turn off";
+            disp_val = {"Backlight will not turn off"};
           } else if (_inactivity == 1) {
-            disp_val = "Backlight will turn off after 30 seconds of inactivity";
+            disp_val = {"Backlight will turn off after", "30 seconds of inactivity"};
           } else {
-            disp_val = "Backlight will turn off after a minute of inactivity";
+            disp_val = {"Backlight will turn off after", "a minute of inactivity"};
           }
-          ez.msgBox("Inactivity timeout", disp_val, "Adjust#Back", false);
-          String b = ez.buttons.wait();
+          ez.msgBox("Inactivity timeout", disp_val, {"Adjust", "Back"}, false);
+          std::string b = ez.buttons.wait();
           if (b == "Adjust")
             _inactivity++;
           if (_inactivity > 2)
@@ -958,1151 +882,6 @@ uint16_t ezBacklight::loop(void *private_data) {
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
-//   C L O C K
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-#ifdef M5EZ_CLOCK
-Timezone ezClock::tz;
-bool ezClock::_on;
-String ezClock::_timezone;
-bool ezClock::_clock12;
-bool ezClock::_am_pm;
-String ezClock::_datetime;
-bool ezClock::_starting = true;
-
-void ezClock::begin() {
-  Preferences prefs;
-  prefs.begin("M5ez", true);  // read-only
-  _on = prefs.getBool("clock_on", true);
-  _timezone = prefs.getString("timezone", "GeoIP");
-  _clock12 = prefs.getBool("clock12", false);
-  _am_pm = prefs.getBool("ampm", false);
-  prefs.end();
-  ez.settings.menuObj.addItem("Clock settings", ez.clock.menu);
-  ez.addEvent(ez.clock.loop);
-  ez.clock.restart();
-}
-
-void ezClock::restart() {
-  ez.header.remove("clock");
-  uint8_t length;
-  if (_on) {
-    if (_clock12) {
-      if (_am_pm) {
-        _datetime = "g:ia";
-        length = 7;
-      } else {
-        _datetime = "g:i";
-        length = 5;
-      }
-    } else {
-      _datetime = "H:i";
-      length = 5;
-    }
-    ez.setFont(ez.theme->clock_font);
-    uint8_t width = length * M5.Lcd.textWidth("5") + ez.theme->header_hmargin * 2;
-    ez.header.insert(RIGHTMOST, "clock", width, ez.clock.draw);
-  }
-}
-
-void ezClock::menu() {
-  bool on_orig = _on;
-  bool clock12_orig = _clock12;
-  bool am_pm_orig = _am_pm;
-  String tz_orig = _timezone;
-  while (true) {
-    ezMenu clockmenu("Clock settings");
-    clockmenu.txtSmall();
-    clockmenu.buttons("up#Back#select##down#");
-    clockmenu.addItem("on|Display clock\t" + (String)(_on ? "on" : "off"));
-    if (_on) {
-      clockmenu.addItem("tz|Timezone\t" + _timezone);
-      clockmenu.addItem("1224|12/24 hour\t" + (String)(_clock12 ? "12" : "24"));
-      if (_clock12) {
-        clockmenu.addItem("ampm|am/pm indicator\t" + (String)(_am_pm ? "on" : "off"));
-      }
-    }
-    switch (clockmenu.runOnce()) {
-      case 1:
-        _on = !_on;
-        ez.clock.restart();
-        break;
-      case 2:
-        _timezone = ez.textInput("Enter timezone");
-        if (_timezone == "")
-          _timezone = "GeoIP";
-        if (tz.setLocation(_timezone))
-          _timezone = tz.getOlsen();
-        break;
-      case 3:
-        _clock12 = !_clock12;
-        ez.clock.restart();
-        break;
-      case 4:
-        _am_pm = !_am_pm;
-        ez.clock.restart();
-        break;
-      case 0:
-        if (_am_pm != am_pm_orig || _clock12 != clock12_orig || _on != on_orig
-            || _timezone != tz_orig) {
-          _writePrefs();
-        }
-        return;
-        //
-    }
-  }
-}
-
-uint16_t ezClock::loop(void *private_data) {
-  ezt::events();
-  if (_starting && timeStatus() != timeNotSet) {
-    _starting = false;
-    if (tz.setLocation(_timezone)) {
-      if (tz.getOlsen() != _timezone) {
-        _timezone = tz.getOlsen();
-        _writePrefs();
-      }
-    }
-    ez.header.draw("clock");
-  } else {
-    if (_on && ezt::minuteChanged())
-      ez.header.draw("clock");
-  }
-  return 250;
-}
-
-void ezClock::draw(uint16_t x, uint16_t w) {
-  if (_starting)
-    return;
-  M5.Lcd.fillRect(x, 0, w, ez.theme->header_height, ez.theme->header_bgcolor);
-  ez.setFont(ez.theme->clock_font);
-  M5.Lcd.setTextColor(ez.theme->header_fgcolor);
-  M5.Lcd.setTextDatum(TL_DATUM);
-  M5.Lcd.drawString(tz.dateTime(_datetime), x + ez.theme->header_hmargin,
-                    ez.theme->header_tmargin + 2);
-}
-
-void ezClock::_writePrefs() {
-  Preferences prefs;
-  prefs.begin("M5ez");
-  prefs.putBool("clock_on", _on);
-  prefs.putString("timezone", _timezone);
-  prefs.putBool("clock12", _clock12);
-  prefs.putBool("ampm", _am_pm);
-  prefs.end();
-}
-
-bool ezClock::waitForSync(const uint16_t timeout /* = 0 */) {
-  unsigned long start = millis();
-  ez.msgBox("Clock sync", "Waiting for clock synchronisation", "", false);
-  while (ezt::timeStatus() != timeSet) {
-    if (timeout && (millis() - start) / 1000 > timeout)
-      return false;
-    delay(25);
-    ez.yield();
-  }
-  return true;
-}
-
-#endif
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-//   F A C E S
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-#ifdef M5EZ_FACES
-
-bool ezFACES::_on;
-
-void ezFACES::begin() {
-  Preferences prefs;
-  prefs.begin("M5ez", true);  // read-only
-  _on = prefs.getBool("faces_on", false);
-  prefs.end();
-  if (_on) {
-    Wire.begin();
-    pinMode(5, INPUT);
-    digitalWrite(5, HIGH);
-    Wire.flush();
-  }
-  ez.settings.menuObj.addItem("FACES keyboard", ez.faces.menu);
-}
-
-void ezFACES::menu() {
-  bool start_state = _on;
-  while (true) {
-    ezMenu facesmenu("FACES keyboard");
-    facesmenu.txtSmall();
-    facesmenu.buttons("up#Back#select##down#");
-    facesmenu.addItem("on|FACES keyboard\t" + (String)(_on ? "attached" : "not attached"));
-    switch (facesmenu.runOnce()) {
-      case 1:
-        _on = !_on;
-        if (_on) {
-          pinMode(5, INPUT);
-          digitalWrite(5, HIGH);
-          Wire.flush();
-        }
-        break;
-      case 0:
-        if (_on != start_state) {
-          Preferences prefs;
-          prefs.begin("M5ez");
-          prefs.putBool("faces_on", _on);
-          prefs.end();
-        }
-        return;
-        //
-    }
-  }
-}
-
-String ezFACES::poll() {
-  if (digitalRead(5) == LOW) {
-    Wire.requestFrom(0x88, 1);
-    String out = "";
-    while (Wire.available()) {
-      out += (char)Wire.read();
-    }
-#ifdef M5EZ_BACKLIGHT
-    ez.backlight.activity();
-#endif
-    return out;
-  }
-  return "";
-}
-
-bool ezFACES::on() {
-  return _on;
-}
-
-#endif
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-//   W I F I
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-#ifdef M5EZ_WIFI
-
-WifiState_t ezWifi::_state;
-uint8_t ezWifi::_current_from_scan;
-uint32_t ezWifi::_wait_until;
-uint32_t ezWifi::_widget_time;
-std::vector<WifiNetwork_t> ezWifi::networks;
-ezProgressBar *ezWifi::_update_progressbar;
-String ezWifi::_update_error;
-bool ezWifi::autoConnect;
-#ifdef M5EZ_WPS
-WiFiEvent_t ezWifi::_WPS_event;
-String ezWifi::_WPS_pin;
-bool ezWifi::_WPS_new_event;
-#endif
-
-void ezWifi::begin() {
-#ifdef M5EZ_WIFI_DEBUG
-  Serial.println("EZWIFI: Initialising");
-#endif
-  WiFi.mode(WIFI_MODE_STA);
-  WiFi.setAutoConnect(false);    // We have our own multi-AP version of this
-  WiFi.setAutoReconnect(false);  // So we turn off the ESP32's versions
-  WiFi.setHostname("M5Stack");
-  ez.wifi.readFlash();
-  _state = EZWIFI_IDLE;
-  const uint8_t cutoffs[] = {0, 20, 40, 70};
-  ez.settings.menuObj.addItem("Wifi settings", ez.wifi.menu);
-  ez.header.insert(RIGHTMOST, "wifi",
-                   sizeof(cutoffs) * (ez.theme->signal_bar_width + ez.theme->signal_bar_gap)
-                       + 2 * ez.theme->header_hmargin,
-                   ez.wifi._drawWidget);
-  ez.addEvent(ez.wifi.loop);
-}
-
-void ezWifi::_drawWidget(uint16_t x, uint16_t w) {
-  const uint8_t cutoffs[] = {0, 20, 40, 70};
-  uint8_t max_bars = sizeof(cutoffs);
-  uint8_t bars;
-  uint16_t left_offset = x + ez.theme->header_hmargin;
-  bars = 0;
-  if (WiFi.isConnected()) {
-    uint8_t signal = map(100 + WiFi.RSSI(), 5, 90, 0, 100);
-    for (uint8_t n = 0; n < sizeof(cutoffs); n++) {  // Determine how many bars signal is.
-      if (signal >= cutoffs[n])
-        bars = n + 1;
-    }
-  }
-  uint8_t top = ez.theme->header_height / 10;
-  uint8_t max_len = ez.theme->header_height * 0.8;
-  uint8_t this_len;
-  for (uint8_t n = 0; n < max_bars; n++) {
-    this_len = ((float)(n + 1) / max_bars) * max_len;
-    M5.Lcd.fillRect(left_offset + n * (ez.theme->signal_bar_width + ez.theme->signal_bar_gap),
-                    top + max_len - this_len, ez.theme->signal_bar_width, this_len,
-                    (n + 1 <= bars ? ez.theme->header_fgcolor : ez.theme->header_bgcolor));
-  }
-}
-
-void ezWifi::add(String ssid, String key) {
-  WifiNetwork_t new_net;
-  new_net.SSID = ssid;
-  new_net.key = key;
-  networks.push_back(new_net);
-}
-
-bool ezWifi::remove(int8_t index) {
-  if (index < 0 || index >= networks.size())
-    return false;
-  networks.erase(networks.begin() + index);
-  return true;
-}
-
-bool ezWifi::remove(String ssid) {
-  return remove(indexForSSID(ssid));
-}
-
-int8_t ezWifi::indexForSSID(String ssid) {
-  for (uint8_t n = 0; n < networks.size(); n++) {
-    if (networks[n].SSID == ssid)
-      return n;
-  }
-  return -1;
-}
-
-void ezWifi::readFlash() {
-  Preferences prefs;
-  networks.clear();
-  prefs.begin("M5ez", true);  // true: read-only
-  autoConnect = prefs.getBool("autoconnect_on", true);
-#ifdef M5EZ_WIFI_DEBUG
-  Serial.println("wifiReadFlash: Autoconnect is " + (String)(autoConnect ? "ON" : "OFF"));
-#endif
-  WifiNetwork_t new_net;
-  String idx;
-  uint8_t index = 1;
-  while (true) {
-    idx = "SSID" + (String)index;
-    String ssid = prefs.getString(idx.c_str(), "");
-    idx = "key" + (String)index;
-    String key = prefs.getString(idx.c_str(), "");
-    if (ssid != "") {
-      new_net.SSID = ssid;
-      new_net.key = key;
-      networks.push_back(new_net);
-#ifdef M5EZ_WIFI_DEBUG
-      Serial.println("wifiReadFlash: Read ssid:" + ssid + " key:" + key);
-#endif
-      index++;
-    } else {
-      break;
-    }
-  }
-  prefs.end();
-}
-
-void ezWifi::writeFlash() {
-  Preferences prefs;
-  String idx;
-  uint8_t n = 1;
-  prefs.begin("M5ez", false);
-  // Remove unknown number of items from NVS, sequentially named SSID1 to SSIDN, and key1 to keyN
-  // where N is the total number of WiFi Networks stored (which may be different than
-  // networks.size() at this point.)
-  while (true) {
-    idx = "SSID" + (String)n;
-    if (!prefs.remove(idx.c_str()))
-      break;
-    idx = "key" + (String)n;
-    prefs.remove(idx.c_str());
-    n++;
-  }
-  prefs.putBool("autoconnect_on", autoConnect);
-#ifdef M5EZ_WIFI_DEBUG
-  Serial.println("wifiWriteFlash: Autoconnect is " + (String)(autoConnect ? "ON" : "OFF"));
-#endif
-  for (n = 0; n < networks.size(); n++) {
-    idx = "SSID" + (String)(n + 1);
-    prefs.putString(idx.c_str(), networks[n].SSID);
-    if (networks[n].key != "") {
-      idx = "key" + (String)(n + 1);
-      prefs.putString(idx.c_str(), networks[n].key);
-#ifdef M5EZ_WIFI_DEBUG
-      Serial.println("wifiWriteFlash: Wrote ssid:" + networks[n].SSID + " key:" + networks[n].key);
-#endif
-    }
-  }
-  prefs.end();
-}
-
-void ezWifi::menu() {
-  _state = EZWIFI_AUTOCONNECT_DISABLED;
-#ifdef M5EZ_WIFI_DEBUG
-  Serial.println("EZWIFI: Disabling autoconnect while in Wifi menu.");
-#endif
-  ezMenu wifimain("Wifi settings");
-  wifimain.txtSmall();
-  wifimain.addItem("onoff | Autoconnect\t" + (String)(autoConnect ? "ON" : "OFF"), NULL, _onOff);
-  wifimain.addItem(
-      "connection | "
-          + (String)(WiFi.isConnected() ? "Connected: " + WiFi.SSID() : "Join a network"),
-      NULL, _connection);
-  wifimain.addItem("Manage autoconnects", _manageAutoconnects);
-  wifimain.buttons("up#Back#select##down#");
-  wifimain.run();
-  _state = EZWIFI_IDLE;
-#ifdef M5EZ_WIFI_DEBUG
-  Serial.println("EZWIFI: Enabling autoconnect exiting Wifi menu.");
-#endif
-}
-
-bool ezWifi::_onOff(ezMenu *callingMenu) {
-  autoConnect = !autoConnect;
-  callingMenu->setCaption("onoff", "Autoconnect\t" + (String)(autoConnect ? "ON" : "OFF"));
-  ez.wifi.writeFlash();
-  return true;
-}
-
-void ezWifi::_manageAutoconnects() {
-  ezMenu autoconnect("Managing autoconnects");
-  if (!networks.size()) {
-    ez.msgBox("No autoconnects", "You have no saved autoconnect networks.", "OK");
-    return;
-  }
-  for (uint8_t n = 0; n < networks.size(); n++) {
-    autoconnect.addItem(networks[n].SSID, NULL, _autoconnectSelected);
-  }
-  autoconnect.txtSmall();
-  autoconnect.buttons("up#Back#Forget##down#");
-  autoconnect.run();
-}
-
-bool ezWifi::_autoconnectSelected(ezMenu *callingMenu) {
-  if (callingMenu->pickButton() == "Forget") {
-    if (ez.msgBox(
-            "Forgetting wifi network",
-            "Are you sure you want | to forget wifi network | " + callingMenu->pickName() + " ?",
-            "Yes##No")
-        == "Yes") {
-      ez.wifi.remove(callingMenu->pick() - 1);
-      callingMenu->deleteItem(callingMenu->pick());
-      ez.wifi.writeFlash();
-    }
-  }
-  return false;
-}
-
-bool ezWifi::_connection(ezMenu *callingMenu) {
-  if (WiFi.isConnected()) {
-    const uint8_t tab = 140;
-    ez.screen.clear();
-    ez.header.show("Current wifi connection");
-    ez.canvas.font(&FreeSans9pt7b);
-    ez.canvas.lmargin(10);
-    ez.canvas.y(ez.canvas.top() + 5);
-    ez.canvas.print("SSID:");
-    ez.canvas.x(tab);
-    ez.canvas.println(WiFi.SSID());
-    ez.canvas.print("Key:");
-    ez.canvas.x(tab);
-    ez.canvas.println(WiFi.psk());
-    ez.canvas.print("My IP:");
-    ez.canvas.x(tab);
-    ez.canvas.println(WiFi.localIP().toString());
-    ez.canvas.print("My MAC:");
-    ez.canvas.x(tab);
-    ez.canvas.println(WiFi.macAddress());
-    ez.canvas.print("My hostname:");
-    ez.canvas.x(tab);
-    ez.canvas.println(WiFi.getHostname());
-    ez.canvas.print("Router IP:");
-    ez.canvas.x(tab);
-    ez.canvas.println(WiFi.gatewayIP().toString());
-    ez.canvas.print("Router BSSID:");
-    ez.canvas.x(tab);
-    ez.canvas.println(WiFi.BSSIDstr());
-    ez.canvas.print("DNS IP:");
-    ez.canvas.x(tab);
-    ez.canvas.println(WiFi.dnsIP(0).toString());
-    if (WiFi.dnsIP(1)) {
-      ez.canvas.x(tab);
-      ez.canvas.println(WiFi.dnsIP(1).toString());
-    }
-    String pressed = ez.buttons.wait("Back#Disconnect#");
-    if (pressed == "Back")
-      return true;
-    if (pressed == "Disconnect") {
-      WiFi.disconnect();
-      while (WiFi.isConnected()) {
-      }
-    }
-
-  } else {
-    String SSID = "", key = "";
-    ezMenu joinmenu("Joining a network");
-    joinmenu.txtSmall();
-    joinmenu.addItem("Scan and join");
-    joinmenu.addItem("SmartConfig");
-#ifdef M5EZ_WPS
-    joinmenu.addItem("WPS Button");
-    joinmenu.addItem("WPS Pin Code");
-#endif
-    joinmenu.buttons("up#Back#select##down#");
-    joinmenu.runOnce();
-
-    if (joinmenu.pickName() == "Scan and join") {
-      ez.msgBox("WiFi setup menu", "Scanning ...", "");
-      WiFi.disconnect();
-      WiFi._setStatus(WL_IDLE_STATUS);
-      delay(100);
-      int16_t n = WiFi.scanNetworks();
-      if (n == 0) {
-        ez.msgBox("WiFi setup menu", "No networks found", "OK");
-      } else {
-        ezMenu networks("Select your netork");
-        networks.txtSmall();
-        for (uint16_t i = 0; i < n; ++i) {
-          // No duplicates (multiple BSSIDs on same SSID)
-          // because we're only picking an SSID here
-          if (!networks.getItemNum(WiFi.SSID(i))) {
-            networks.addItem(WiFi.SSID(i));
-          }
-        }
-        networks.buttons("up#Back#select##down#");
-        if (networks.runOnce()) {
-          SSID = networks.pickName();
-          if (WiFi.encryptionType(networks.pick() - 1) == WIFI_AUTH_OPEN) {
-            WiFi.mode(WIFI_MODE_STA);
-            WiFi.begin(SSID.c_str());
-          } else {
-            key = ez.textInput("Enter wifi password");
-            WiFi.mode(WIFI_MODE_STA);
-            WiFi.begin(SSID.c_str(), key.c_str());
-          }
-          ez.msgBox("WiFi setup menu", "Connecting ...", "Abort", false);
-          String button;
-          int16_t status;
-          while (button = ez.buttons.poll()) {
-            if (button == "Abort") {
-              WiFi.disconnect();
-              break;
-            }
-            status = WiFi.status();
-            if (status == WL_CONNECTED) {
-              break;
-            }
-            if (status == WL_CONNECT_FAILED || status == WL_NO_SSID_AVAIL) {
-              ez.msgBox("WiFi setup menu", "Connect failed. | | (Wrong password?)", "OK");
-              break;
-            }
-          }
-        }
-        WiFi.scanDelete();
-      }
-    }
-
-    if (joinmenu.pickName() == "SmartConfig") {
-      ez.msgBox("SmartConfig setup", "Waiting for SmartConfig", "Abort", false);
-      WiFi.mode(WIFI_MODE_STA);
-      WiFi.beginSmartConfig();
-      bool done_already = false;
-      while (!WiFi.isConnected()) {
-        if (ez.buttons.poll() == "Abort") {
-          WiFi.stopSmartConfig();
-          break;
-        }
-        if (WiFi.smartConfigDone() && !done_already) {
-          ez.msgBox("SmartConfig setup", "SmartConfig received | Connecting ...", "Abort", false);
-          done_already = true;
-        }
-      }
-    }
-
-#ifdef M5EZ_WPS
-    if (joinmenu.pickName().substring(0, 3) == "WPS") {
-      ez.msgBox("WPS setup", "Waiting for WPS", "Abort", false);
-      WiFi.mode(WIFI_MODE_STA);
-      static esp_wps_config_t config;
-      config.crypto_funcs = &g_wifi_default_wps_crypto_funcs;
-      strcpy(config.factory_info.manufacturer, "ESPRESSIF");
-      strcpy(config.factory_info.model_number, "ESP32");
-      strcpy(config.factory_info.model_name, "ESPRESSIF IOT");
-      strcpy(config.factory_info.device_name, "ESP STATION");
-      if (joinmenu.pickName() == "WPS Button") {
-        config.wps_type = WPS_TYPE_PBC;
-      } else {
-        config.wps_type = WPS_TYPE_PIN;
-      }
-      WiFi.onEvent(_WPShelper);
-      esp_wifi_wps_enable(&config);
-      esp_wifi_wps_start(0);
-
-      _WPS_new_event = false;
-      while (!WiFi.isConnected()) {
-        if (ez.buttons.poll() == "Abort") {
-          esp_wifi_wps_disable();
-          break;
-        }
-        if (_WPS_new_event) {
-          switch (_WPS_event) {
-            case SYSTEM_EVENT_STA_WPS_ER_SUCCESS:
-              ez.msgBox("WPS setup", "WPS successful | Connecting ...", "Abort", false);
-              esp_wifi_wps_disable();
-              delay(10);
-              WiFi.begin();
-              break;
-            case SYSTEM_EVENT_STA_WPS_ER_FAILED:
-            case SYSTEM_EVENT_STA_WPS_ER_TIMEOUT:
-              ez.msgBox("WPS setup", "WPS failed or timed out | Retrying ...", "Abort", false);
-              esp_wifi_wps_disable();
-              esp_wifi_wps_enable(&config);
-              esp_wifi_wps_start(0);
-              break;
-            case SYSTEM_EVENT_STA_WPS_ER_PIN:
-              ez.msgBox("WPS setup", "WPS PIN: " + _WPS_pin, "Abort", false);
-              break;
-            default:
-              break;
-          }
-          _WPS_new_event = false;
-        }
-      }
-    }
-#endif
-
-    if (WiFi.isConnected())
-      _askAdd();
-  }
-  callingMenu->setCaption(
-      "connection", (String)(WiFi.isConnected() ? "Connected: " + WiFi.SSID() : "Join a network"));
-  return true;
-}
-
-#ifdef M5EZ_WPS
-void ezWifi::_WPShelper(WiFiEvent_t event, system_event_info_t info) {
-  _WPS_event = event;
-  _WPS_new_event = true;
-  if (event == SYSTEM_EVENT_STA_WPS_ER_PIN) {
-    char wps_pin[9];
-    for (int8_t i = 0; i < 8; i++) {
-      wps_pin[i] = info.sta_er_pin.pin_code[i];
-    }
-    wps_pin[8] = '\0';
-    _WPS_pin = String(wps_pin);
-  }
-}
-#endif
-
-void ezWifi::_askAdd() {
-  for (uint8_t n = 0; n < networks.size(); n++) {
-    if (networks[n].SSID == WiFi.SSID())
-      return;
-  }
-  if (ez.msgBox("Wifi settings", "Save this network | to your autoconnects?", "no##yes") == "yes") {
-    ez.wifi.add(WiFi.SSID(), WiFi.psk());
-    ez.wifi.writeFlash();
-  }
-}
-
-uint16_t ezWifi::loop(void *private_data) {
-  if (millis() > _widget_time + ez.theme->signal_interval) {
-    ez.header.draw("wifi");
-    _widget_time = millis();
-  }
-  if (WiFi.isConnected() && _state != EZWIFI_AUTOCONNECT_DISABLED && _state != EZWIFI_IDLE) {
-    _state = EZWIFI_IDLE;
-#ifdef M5EZ_WIFI_DEBUG
-    Serial.println("EZWIFI: Connected, returning to IDLE state");
-#endif
-  }
-  if (!autoConnect || WiFi.isConnected() || networks.size() == 0)
-    return 250;
-  int8_t scanresult;
-  switch (_state) {
-    case EZWIFI_WAITING:
-      if (millis() < _wait_until)
-        return 250;
-    case EZWIFI_IDLE:
-#ifdef M5EZ_WIFI_DEBUG
-      Serial.println("EZWIFI: Starting scan");
-#endif
-      WiFi.mode(WIFI_MODE_STA);
-      WiFi.scanNetworks(true);
-      _current_from_scan = 0;
-      _state = EZWIFI_SCANNING;
-      _wait_until = millis() + 10000;
-      break;
-    case EZWIFI_SCANNING:
-      scanresult = WiFi.scanComplete();
-      switch (scanresult) {
-        case WIFI_SCAN_RUNNING:
-          break;
-        case WIFI_SCAN_FAILED:
-#ifdef M5EZ_WIFI_DEBUG
-          Serial.println("EZWIFI: Scan failed");
-#endif
-          _state = EZWIFI_WAITING;
-          _wait_until = millis() + 60000;
-          WiFi.scanDelete();
-          return 250;
-        default:
-#ifdef M5EZ_WIFI_DEBUG
-          Serial.println("EZWIFI: Scan got " + (String)scanresult + " networks");
-#endif
-          for (uint8_t n = _current_from_scan; n < scanresult; n++) {
-            for (uint8_t m = 0; m < networks.size(); m++) {
-              String ssid = networks[m].SSID;
-              String key = networks[m].key;
-              if (ssid == WiFi.SSID(n)) {
-#ifdef M5EZ_WIFI_DEBUG
-                Serial.println("EZWIFI: Match: " + WiFi.SSID(n) + ", connecting...");
-#endif
-                WiFi.mode(WIFI_MODE_STA);
-                WiFi.begin(ssid.c_str(), key.c_str());
-                _state = EZWIFI_CONNECTING;
-                _wait_until = millis() + 7000;
-                return 250;
-              }
-            }
-          }
-#ifdef M5EZ_WIFI_DEBUG
-          Serial.println("EZWIFI: No (further) matches, waiting...");
-#endif
-          _state = EZWIFI_WAITING;
-          _wait_until = millis() + 60000;
-          WiFi.scanDelete();
-          //
-      }
-    case EZWIFI_CONNECTING:
-      if (millis() > _wait_until) {
-#ifdef M5EZ_WIFI_DEBUG
-        Serial.println("EZWIFI: Connect timed out...");
-#endif
-        WiFi.disconnect();
-        _current_from_scan++;
-        _state = EZWIFI_SCANNING;
-      }
-    case EZWIFI_AUTOCONNECT_DISABLED:
-      return 250;
-    default:
-      break;
-  }
-  return 250;
-}
-
-bool ezWifi::update(String url, const char *root_cert, ezProgressBar *pb /* = NULL */) {
-  _update_progressbar = pb;
-
-  if (!WiFi.isConnected()) {
-    _update_error = "No WiFi connection.";
-    return false;
-  }
-
-  if (!url.startsWith("https://")) {
-    _update_error = "URL must start with 'https://'";
-    return false;
-  }
-
-  url = url.substring(8);
-
-  String host, file;
-  uint16_t port;
-  int16_t first_slash_pos = url.indexOf("/");
-  if (first_slash_pos == -1) {
-    host = url;
-    file = "/";
-  } else {
-    host = url.substring(0, first_slash_pos);
-    file = url.substring(first_slash_pos);
-  }
-  int16_t colon = host.indexOf(":");
-
-  if (colon == -1) {
-    port = 443;
-  } else {
-    host = host.substring(0, colon);
-    port = host.substring(colon + 1).toInt();
-  }
-
-  WiFiClientSecure client;
-  client.setTimeout(20000);
-  client.setCACert(root_cert);
-
-  int contentLength = 0;
-
-  if (!client.connect(host.c_str(), port)) {
-    _update_error = "Connection to " + String(host) + " failed.";
-    return false;
-  }
-
-  client.print(String("GET ") + file + " HTTP/1.1\r\n" + "Host: " + host + "\r\n"
-               + "Cache-Control: no-cache\r\n" + "Connection: close\r\n\r\n");
-
-  unsigned long timeout = millis();
-  while (!client.available()) {
-    if (millis() - timeout > 10000) {
-      _update_error = "Client Timeout";
-      client.stop();
-      return false;
-    }
-  }
-
-  // Process header
-  while (client.available()) {
-    String line = client.readStringUntil('\n');
-    line.trim();
-    if (!line.length())
-      break;  // empty line, assume headers done
-
-    if (line.startsWith("HTTP/1.1")) {
-      String http_response = line.substring(line.indexOf(" ") + 1);
-      http_response.trim();
-      if (http_response.indexOf("200") == -1) {
-        _update_error = "Got response: \"" + http_response + "\", must be 200";
-        return false;
-      }
-    }
-
-    if (line.startsWith("Content-Length: ")) {
-      contentLength = atoi(line.substring(line.indexOf(":") + 1).c_str());
-      if (contentLength <= 0) {
-        _update_error = "Content-Length zero";
-        return false;
-      }
-    }
-
-    if (line.startsWith("Content-Type: ")) {
-      String contentType = line.substring(line.indexOf(":") + 1);
-      contentType.trim();
-      if (contentType != "application/octet-stream") {
-        _update_error =
-            "Content-Type must be \"application/octet-stream\", got \"" + contentType + "\"";
-        return false;
-      }
-    }
-  }
-
-  // Process payload
-  Update.onProgress(_update_progress);
-
-  if (!Update.begin(contentLength)) {
-    _update_error = "Not enough space to begin OTA";
-    client.flush();
-    return false;
-  }
-
-  size_t written = Update.writeStream(client);
-
-  if (!Update.end()) {
-    _update_error = "Error: " + String(_update_err2str(Update.getError())) + " | (after "
-                    + String(written) + " of " + String(contentLength) + " bytes)";
-    return false;
-  }
-
-  if (!Update.isFinished()) {
-    _update_error = "Update not finished. Something went wrong.";
-    return false;
-  }
-
-  return true;
-}
-
-void ezWifi::_update_progress(int done, int total) {
-  if (ez.buttons.poll() != "") {
-    Update.abort();
-  } else {
-    if (total && _update_progressbar != NULL) {
-      _update_progressbar->value((done * 100) / total);
-    }
-  }
-}
-
-String ezWifi::updateError() {
-  return _update_error;
-}
-
-// Stupid Updater library only wants to print readable errors to a Stream object,
-// so we just copied its _err2str function. Bleh...
-String ezWifi::_update_err2str(uint8_t _error) {
-  if (_error == UPDATE_ERROR_OK) {
-    return ("No Error");
-  } else if (_error == UPDATE_ERROR_WRITE) {
-    return ("Flash Write Failed");
-  } else if (_error == UPDATE_ERROR_ERASE) {
-    return ("Flash Erase Failed");
-  } else if (_error == UPDATE_ERROR_READ) {
-    return ("Flash Read Failed");
-  } else if (_error == UPDATE_ERROR_SPACE) {
-    return ("Not Enough Space");
-  } else if (_error == UPDATE_ERROR_SIZE) {
-    return ("Bad Size Given");
-  } else if (_error == UPDATE_ERROR_STREAM) {
-    return ("Stream Read Timeout");
-  } else if (_error == UPDATE_ERROR_MD5) {
-    return ("MD5 Check Failed");
-  } else if (_error == UPDATE_ERROR_MAGIC_BYTE) {
-    return ("Wrong Magic Byte");
-  } else if (_error == UPDATE_ERROR_ACTIVATE) {
-    return ("Could Not Activate The Firmware");
-  } else if (_error == UPDATE_ERROR_NO_PARTITION) {
-    return ("Partition Could Not be Found");
-  } else if (_error == UPDATE_ERROR_BAD_ARGUMENT) {
-    return ("Bad Argument");
-  } else if (_error == UPDATE_ERROR_ABORT) {
-    return ("Aborted");
-  }
-  return ("UNKNOWN");
-}
-
-#endif
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-//   B L E
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-#ifdef M5EZ_BLE
-
-class M5ezClientCallback: public BLEClientCallbacks {
-  void onConnect(BLEClient *) {}
-  void onDisconnect(BLEClient *) { ez.ble._cleanup(); }
-} _bleClientCallback;
-
-// https://www.bluetooth.com/specifications/gatt/services/
-const std::vector<std::pair<uint16_t, String>> ezBLE::_gattUuids = {
-    {0x1800, "Generic Access"},
-    {0x1811, "Alert Notification Service"},
-    {0x1815, "Automation IO"},
-    {0x180F, "Battery Service"},
-    {0x183B, "Binary Sensor"},
-    {0x1810, "Blood Pressure"},
-    {0x181B, "Body Composition"},
-    {0x181E, "Bond Management Service"},
-    {0x181F, "Continuous Glucose Monitoring"},
-    {0x1805, "Current Time Service"},
-    {0x1818, "Cycling Power"},
-    {0x1816, "Cycling Speed and Cadence"},
-    {0x180A, "Device Information"},
-    {0x183C, "Emergency Configuration"},
-    {0x181A, "Environmental Sensing"},
-    {0x1826, "Fitness Machine"},
-    {0x1801, "Generic Attribute"},
-    {0x1808, "Glucose"},
-    {0x1809, "Health Thermometer"},
-    {0x180D, "Heart Rate"},
-    {0x1823, "HTTP Proxy"},
-    {0x1812, "Human Interface Device"},
-    {0x1802, "Immediate Alert"},
-    {0x1821, "Indoor Positioning"},
-    {0x183A, "Insulin Delivery"},
-    {0x1820, "Internet Protocol Support Service"},
-    {0x1803, "Link Loss"},
-    {0x1819, "Location and Navigation"},
-    {0x1827, "Mesh Provisioning Service"},
-    {0x1828, "Mesh Proxy Service"},
-    {0x1807, "Next DST Change Service"},
-    {0x1825, "Object Transfer Service"},
-    {0x180E, "Phone Alert Status Service"},
-    {0x1822, "Pulse Oximeter Service"},
-    {0x1829, "Reconnection Configuration"},
-    {0x1806, "Reference Time Update Service"},
-    {0x1814, "Running Speed and Cadence"},
-    {0x1813, "Scan Parameters"},
-    {0x1824, "Transport Discovery"},
-    {0x1804, "Tx Power"},
-    {0x181C, "User Data"},
-    {0x181D, "Weight Scale"},
-};
-
-bool ezBLE::_on = false;
-bool ezBLE::_initialized = false;
-std::vector<BLEClient *> ezBLE::_clients;
-
-void ezBLE::begin() {
-  ez.ble.readFlash();
-  ez.settings.menuObj.addItem("BLE settings", ez.ble.menu);
-  if (_on) {
-    _refresh();
-  }
-}
-
-void ezBLE::readFlash() {
-  Preferences prefs;
-  prefs.begin("M5ez", true);  // true: read-only
-  _on = prefs.getBool("ble_on", false);
-  prefs.end();
-}
-
-void ezBLE::writeFlash() {
-  Preferences prefs;
-  prefs.begin("M5ez");
-  prefs.putBool("ble_on", _on);
-  prefs.end();
-}
-
-void ezBLE::menu() {
-  bool on_orig = _on;
-  while (true) {
-    ezMenu blemenu("BLE Settings");
-    blemenu.txtSmall();
-    blemenu.addItem("on|Turn On\t" + (String)(_on ? "on" : "off"));
-    if (_on) {
-      blemenu.addItem("Scan and connect", NULL, _scan);
-      blemenu.addItem("Clients", NULL, _listClients);
-    }
-    blemenu.buttons("up#Back#select##down#");
-    switch (blemenu.runOnce()) {
-      case 1:
-        _on = !_on;
-        _refresh();
-        break;
-      case 0:
-        if (_on != on_orig) {
-          writeFlash();
-        }
-        return;
-    }
-  }
-}
-
-void ezBLE::disconnect() {
-  for (auto &client : _clients) {
-    if (client->isConnected())
-      client->disconnect();
-  }
-  _clients.clear();
-}
-
-BLEClient *ezBLE::getClient(uint16_t index) {
-  if (index >= _clients.size())
-    return nullptr;
-  return _clients[index];
-}
-
-uint16_t ezBLE::getClientCount() {
-  return static_cast<uint16_t>(_clients.size());
-}
-
-bool ezBLE::_scan(ezMenu *callingMenu) {
-  BLEScan *bleScan = BLEDevice::getScan();  // create new scan
-  bleScan->setActiveScan(true);             // active scan uses more power, but get results faster
-  bleScan->setInterval(100);
-  bleScan->setWindow(99);  // less or equal setInterval value
-  ez.msgBox("Bluetooth", "Scanning ...", "");
-  BLEScanResults foundDevices = bleScan->start(5, false);
-  ezMenu devicesmenu("Found " + String(foundDevices.getCount()) + " devices");
-  devicesmenu.txtSmall();
-  for (int i = 0; i < foundDevices.getCount(); i++) {
-    const char *name = nullptr;
-    if (foundDevices.getDevice(i).getName().size() == 0)
-      name = foundDevices.getDevice(i).getAddress().toString().c_str();
-    else
-      name = foundDevices.getDevice(i).getName().c_str();
-    devicesmenu.addItem(name);
-  }
-  devicesmenu.buttons("up#Back#select##down#");
-  if (devicesmenu.runOnce()) {
-    BLEAdvertisedDevice device = foundDevices.getDevice(devicesmenu.pick() - 1);
-    _connect(device);
-  }
-  bleScan->clearResults();
-  return true;
-}
-
-void ezBLE::_connect(class BLEAdvertisedDevice &device) {
-  ez.msgBox("Bluetooth", "Connecting ...", "");
-  BLEClient *client = BLEDevice::createClient();
-  client->setClientCallbacks(&_bleClientCallback);
-  if (client->connect(&device)) {
-    _clients.push_back(client);
-    ez.msgBox("Bluetooth", "Device connected.");
-  } else {
-    delete client;
-    ez.msgBox("Bluetooth", "Connection failed!");
-  }
-}
-
-bool ezBLE::_listClients(ezMenu *callingMenu) {
-  ezMenu clientsmenu("Clients");
-  clientsmenu.txtSmall();
-  for (auto &client : _clients) {
-    clientsmenu.addItem(client->getPeerAddress().toString().c_str());
-  }
-  clientsmenu.buttons("up#Back#select##down#");
-  while (clientsmenu.runOnce()) {
-    if (!_showClient(_clients[clientsmenu.pick() - 1]))
-      return false;
-  }
-  return true;
-}
-
-bool ezBLE::_showClient(BLEClient *client) {
-  ezMenu clientmenu(String(client->getPeerAddress().toString().c_str()));
-  clientmenu.txtSmall();
-  clientmenu.buttons("up#Back#select##down#");
-  auto &services = *client->getServices();
-  for (auto &service : services) {
-    bool found = false;
-    for (auto &pair : _gattUuids) {
-      if (BLEUUID(pair.first).equals(service.second->getUUID())) {
-        clientmenu.addItem(pair.second);
-        found = true;
-        break;
-      }
-    }
-    if (!found)
-      clientmenu.addItem(service.first.c_str());
-  }
-  clientmenu.addItem("Disconnect");
-  while (clientmenu.runOnce()) {
-    if (clientmenu.pickName() == "Disconnect") {
-      client->disconnect();
-      return false;
-    }
-  }
-  return true;
-}
-
-void ezBLE::_cleanup() {
-  if (_clients.size() > 0) {
-    _clients.erase(std::remove_if(_clients.begin(), _clients.end(),
-                                  [](BLEClient *client) {
-                                    bool shouldRemove = !client->isConnected();
-                                    if (shouldRemove)
-                                      delete client;
-                                    return shouldRemove;
-                                  }),
-                   _clients.end());
-  }
-}
-
-void ezBLE::_refresh() {
-  if (_on) {
-    if (!_initialized) {
-      _initialized = true;
-      BLEDevice::init(M5EZ_BLE_DEVICE_NAME);
-    }
-  } else {
-    disconnect();
-    if (_initialized) {
-      _initialized = false;
-      _cleanup();
-      BLEDevice::deinit(false);
-    }
-  }
-}
-
-#endif
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
 //   B A T T E R Y
 //
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2111,47 +890,9 @@ void ezBLE::_refresh() {
 bool ezBattery::_on = false;
 
 void ezBattery::begin() {
-  Wire.begin();
-  ez.battery.readFlash();
-  ez.settings.menuObj.addItem("Battery settings", ez.battery.menu);
   _on = true;
   if (_on) {
     _refresh();
-  }
-}
-
-void ezBattery::readFlash() {
-  Preferences prefs;
-  prefs.begin("M5ez", true);  // true: read-only
-  _on = prefs.getBool("battery_icon_on", false);
-  prefs.end();
-}
-
-void ezBattery::writeFlash() {
-  Preferences prefs;
-  prefs.begin("M5ez");
-  prefs.putBool("battery_icon_on", _on);
-  prefs.end();
-}
-
-void ezBattery::menu() {
-  bool on_orig = _on;
-  while (true) {
-    ezMenu clockmenu("Battery settings");
-    clockmenu.txtSmall();
-    clockmenu.buttons("up#Back#select##down#");
-    clockmenu.addItem("on|Display battery\t" + (String)(_on ? "on" : "off"));
-    switch (clockmenu.runOnce()) {
-      case 1:
-        _on = !_on;
-        _refresh();
-        break;
-      case 0:
-        if (_on != on_orig) {
-          writeFlash();
-        }
-        return;
-    }
   }
 }
 
@@ -2239,31 +980,13 @@ constexpr ezCanvas &M5ez::c;
 ezButtons M5ez::buttons;
 constexpr ezButtons &M5ez::b;
 ezSettings M5ez::settings;
-#ifdef M5EZ_WIFI
-ezWifi M5ez::wifi;
-constexpr ezWifi &M5ez::w;
-#endif
-#ifdef M5EZ_BLE
-ezBLE M5ez::ble;
-#endif
 #ifdef M5EZ_BATTERY
 ezBattery M5ez::battery;
 #endif
 #ifdef M5EZ_BACKLIGHT
 ezBacklight M5ez::backlight;
 #endif
-#ifdef M5EZ_CLOCK
-ezClock M5ez::clock;
-#endif
-#ifdef M5EZ_FACES
-ezFACES M5ez::faces;
-#endif
 std::vector<event_t> M5ez::_events;
-
-// ez.textInput
-int16_t M5ez::_text_cursor_x, M5ez::_text_cursor_y, M5ez::_text_cursor_h, M5ez::_text_cursor_w;
-bool M5ez::_text_cursor_state;
-long M5ez::_text_cursor_millis;
 
 void M5ez::begin() {
   auto cfg = M5.config();
@@ -2324,39 +1047,15 @@ void M5ez::redraw() {
   _redraw = true;
 }
 
-static const char *_keydefs[] PROGMEM = {
-    "KB3|qrstu.#SP#KB4|vwxyz,#Del#KB5|More#LCK:|Lock#KB1|abcdefgh#KB2|ijklmnop#Done",  // KB0
-    "c#d#e#f#g#h#a#b#Back",                                                            // KB1
-    "k#l#m#n#o#p#i#j#Back",                                                            // KB2
-    "s#t#u#.###q#r#Back",                                                              // KB3
-    "x#y#z#,###v#w#Back",                                                              // KB4
-    "KB8|Q-U.#SP#KB9|V-Z,#Del#KB10|More#LCK:CAPS|Lock#KB6|A-H#KB7|I-P#Done",           // KB5
-    "C#D#E#F#G#H#A#B#Back",                                                            // KB6
-    "K#L#M#N#O#P#I#J#Back",                                                            // KB7
-    "S#T#U#.###Q#R#Back",                                                              // KB8
-    "X#Y#Z#,###V#W#Back",                                                              // KB9
-    "KB11|1-5.#SP#KB12|6-0,#Del#KB13|More#LCK:NUM|Lock###Done",                        // KB10
-    "1#2#3#4#5#,###Back",                                                              // KB11
-    "6#7#8#9#0#.###Back",                                                              // KB12
-    "KB14|!?:;\\#$^&#SP#KB15|*()_-+=\\|#Del#KB0|More#LCK:SYM|Lock#KB16|'\"`@%\\/"
-    "#KB17|<>{}[]()#Done",     // KB13
-    "!#?#:#;#\\##$#^#&#Back",  // KB14
-    "*#(#)#_#-#+#=#\\|#Back",  // KB15
-    "'#\"#`#@#%#/#\\##Back",   // KB16
-    "<#>#{#}#[#]#(#)#Back",    // KB17
-    ".#,#Del##Done#"           // KB18
-
-};
-
 // ez.msgBox
 
-String M5ez::msgBox(String header,
-                    String msg,
-                    String buttons /* = "OK" */,
-                    const bool blocking /* = true */,
-                    const GFXfont *font /* = NULL */,
-                    uint16_t color /* = NO_COLOR */,
-                    const bool clear /* = true */) {
+std::string M5ez::msgBox(std::string header,
+                         std::vector<std::string> msg,
+                         std::vector<std::string> buttons /* = "OK" */,
+                         const bool blocking /* = true */,
+                         const GFXfont *font /* = NULL */,
+                         uint16_t color /* = NO_COLOR */,
+                         const bool clear /* = true */) {
   if (ez.header.title() != header) {
     ez.screen.clear();
     if (header != "")
@@ -2372,7 +1071,7 @@ String M5ez::msgBox(String header,
     color = ez.theme->msg_color;
   ez.buttons.show(buttons);
   std::vector<line_t> lines;
-  msg.replace("|", (String) char(13));
+  // msg.replace("|", (String) char(13));
   M5.Lcd.setTextDatum(CC_DATUM);
   M5.Lcd.setTextColor(color);
   ez.setFont(font);
@@ -2384,10 +1083,10 @@ String M5ez::msgBox(String header,
     if (!clear) {
       M5.Lcd.fillRect(0, y - font_h / 2, TFT_W, font_h, ez.theme->background);
     }
-    M5.Lcd.drawString(lines[n].line, TFT_W / 2, y);
+    M5.Lcd.drawString(lines[n].line.c_str(), TFT_W / 2, y);
   }
-  if (buttons != "" && blocking) {
-    String ret = ez.buttons.wait();
+  if (buttons.size() != 0 && blocking) {
+    std::string ret = ez.buttons.wait();
     ez.screen.clear();
     return ret;
   } else {
@@ -2395,492 +1094,32 @@ String M5ez::msgBox(String header,
   }
 }
 
-// ez.textInput
-
-String M5ez::textInput(String header /* = "" */, String defaultText /* = "" */) {
-  int16_t current_kb = 0, prev_kb = 0, locked_kb = 0;
-#ifdef M5EZ_FACES
-  if (ez.faces.on()) {
-    current_kb = locked_kb = prev_kb = ez.theme->input_faces_btns;
-    ez.faces.poll();  // flush key buffer in FACES
-  }
-#endif
-  String tmpstr;
-  String text = defaultText;
-  ez.screen.clear();
-  if (header != "")
-    ez.header.show(header);
-  _drawTextInputBox(text);
-  String key;
-  ez.buttons.show(_keydefs[current_kb]);
-
-  while (true) {
-    key = ez.buttons.poll();
-#ifdef M5EZ_FACES
-    if (ez.faces.on() && key == "")
-      key = ez.faces.poll();
-#endif
-    if (key == "Done" || key == (String) char(13))
-      return text;
-    if (key.substring(0, 2) == "KB") {
-      prev_kb = current_kb;
-      tmpstr = key.substring(2);
-      current_kb = tmpstr.toInt();
-      ez.buttons.show(_keydefs[current_kb]);
-      key = "";
-    }
-    if (key.substring(0, 4) == "LCK:") {
-      if (locked_kb != current_kb) {
-        _drawTextInputLockString(key.substring(4));
-        locked_kb = current_kb;
-      } else {
-        _drawTextInputLockString("");
-        locked_kb = 0;
-        current_kb = 0;
-        ez.buttons.show(_keydefs[current_kb]);
-      }
-      key = "";
-    }
-    if (key == "Back") {
-      current_kb = prev_kb;
-      ez.buttons.show(_keydefs[current_kb]);
-      key = "";
-    }
-    if (key == "Del" || key == (String) char(8) || key == (String) char(127)) {
-      text = text.substring(0, text.length() - 1);
-      _drawTextInputBox(text);
-      key = "";
-    }
-    if (key == "SP")
-      key = " ";
-    if (key >= " " && key <= "~") {
-      current_kb = locked_kb;
-      ez.buttons.show(_keydefs[current_kb]);
-      text += key;
-      _drawTextInputBox(text);
-    }
-
-    _textCursor();
-  }
-}
-
-void M5ez::_drawTextInputLockString(String text) {
-  M5.Lcd.setTextColor(TFT_RED);
-  ez.setFont(ez.theme->input_keylock_font);
-  M5.Lcd.setTextDatum(TR_DATUM);
-  int16_t text_h = ez.fontHeight();
-  M5.Lcd.fillRect(0, _text_cursor_y + ez.theme->input_vmargin + 10 + text_h, TFT_W, text_h,
-                  ez.screen.background());
-  M5.Lcd.drawString(text, TFT_W - ez.theme->input_hmargin - 10,
-                    _text_cursor_y + ez.theme->input_vmargin + text_h + 10);
-}
-
-void M5ez::_drawTextInputBox(String text) {
-  int16_t text_w;
-  int16_t box_w = TFT_W - 2 * ez.theme->input_hmargin;
-  ez.setFont(ez.theme->input_font);
-  int16_t text_h = ez.fontHeight();
-  _text_cursor_y = ez.canvas.top() + ez.theme->input_top + ez.theme->input_vmargin;
-  _text_cursor_h = text_h;
-  _text_cursor_w = M5.Lcd.textWidth("A");
-  M5.Lcd.fillRoundRect(ez.theme->input_hmargin, ez.canvas.top() + ez.theme->input_top, box_w,
-                       text_h + ez.theme->input_vmargin * 2, 8, ez.theme->input_bgcolor);
-  _text_cursor_y = ez.canvas.top() + ez.theme->input_top + ez.theme->input_vmargin;
-  M5.Lcd.setTextColor(ez.theme->input_fgcolor);
-  String disp_text = text;
-  // chop off characters from the beginning of displayed string until it fits
-  while (true) {
-    text_w = M5.Lcd.textWidth(disp_text);
-    if (text_w + _text_cursor_w > box_w) {
-      disp_text = disp_text.substring(1);
-    } else {
-      break;
-    }
-  }
-
-  // For some reason the text rendering prints a monospace font with a space at the end with a very
-  // narrow space
-  if (disp_text.substring(disp_text.length() - 1) == " ")
-    disp_text += "  ";
-
-  M5.Lcd.setTextDatum(TC_DATUM);
-  M5.Lcd.drawString(disp_text, TFT_W / 2 - _text_cursor_w / 2,
-                    ez.canvas.top() + ez.theme->input_top + ez.theme->input_vmargin);
-  _text_cursor_x = TFT_W / 2 + text_w / 2 - _text_cursor_w / 2 + 2;
-  _textCursor(true);  // draw the  cursor block
-}
-
-void M5ez::_textCursor() {
-  if (ez.theme->input_cursor_blink > 0) {
-    if (millis() - _text_cursor_millis > ez.theme->input_cursor_blink) {
-      _textCursor(!_text_cursor_state);
-    }
-  }
-}
-
-void M5ez::_textCursor(bool state) {
-  if (state)
-    M5.Lcd.fillRect(_text_cursor_x, _text_cursor_y, _text_cursor_w, _text_cursor_h,
-                    ez.theme->input_fgcolor);
-  if (!state)
-    M5.Lcd.fillRect(_text_cursor_x, _text_cursor_y, _text_cursor_w, _text_cursor_h,
-                    ez.theme->input_bgcolor);
-  _text_cursor_state = state;
-  _text_cursor_millis = millis();
-}
-
-String M5ez::textBox(String header /*= ""*/,
-                     String text /*= "" */,
-                     bool readonly /*= false*/,
-                     String buttons /*= "up#Done#down"*/,
-                     const GFXfont *font /* = NULL */,
-                     uint16_t color /* = NO_COLOR */) {
-  if (!font)
-    font = ez.theme->tb_font;
-  if (color == NO_COLOR)
-    color = ez.theme->tb_color;
-#ifdef M5EZ_FACES
-  if (ez.faces.on()) {
-    ez.faces.poll();  // flush key buffer in FACES
-  } else {
-    readonly = true;
-  }
-#endif
-  std::vector<line_t> lines;
-  ez.screen.clear();
-  uint16_t cursor_pos = text.length();
-  bool cursor_state = false;
-  long cursor_time = 0;
-  if (header != "")
-    ez.header.show(header);
-  int8_t per_line_h = ez.fontHeight();
-  String tmp_buttons = buttons;
-  tmp_buttons.replace("up", "");
-  tmp_buttons.replace("down", "");
-  ez.buttons.show(
-      tmp_buttons);  // we need to draw the buttons here to make sure ez.canvas.height() is correct
-  uint8_t lines_per_screen = (ez.canvas.height()) / per_line_h;
-  uint8_t remainder = (ez.canvas.height()) % per_line_h;
-  _wrapLines(text, ez.canvas.width() - 2 * ez.theme->tb_hmargin, lines);
-  uint16_t offset = 0;
-  bool redraw = true;
-  ez.setFont(font);
-  uint8_t cursor_width = M5.Lcd.textWidth("|");
-  uint8_t cursor_height = per_line_h * 0.8;
-  int16_t cursor_x = 0;
-  int16_t cursor_y = 0;
-  while (true) {
-    if (redraw) {
-      if (!readonly && cursor_x && cursor_y)
-        M5.Lcd.fillRect(cursor_x, cursor_y, cursor_width, cursor_height,
-                        ez.screen.background());  // Remove current cursor
-      cursor_x = cursor_y = 0;
-      tmp_buttons = buttons;
-      if (offset >= lines.size() - lines_per_screen) {
-        tmp_buttons.replace("down", "");
-      }
-      if (offset <= 0) {
-        offset = 0;
-        tmp_buttons.replace("up", "");
-      }
-      ez.buttons.show(tmp_buttons);
-      ez.setFont(font);
-      M5.Lcd.setTextColor(color, ez.screen.background());
-      M5.Lcd.setTextDatum(TL_DATUM);
-      uint16_t x, y;
-      int16_t sol, eol;
-      String this_line;
-      if (lines.size() > 0) {
-        for (int8_t n = offset; n < offset + lines_per_screen; n++) {
-          if (n < lines.size() - 1) {
-            this_line = lines[n].line;
-            sol = lines[n].position;
-            eol = lines[n + 1].position - 1;
-          } else if (n == lines.size() - 1) {
-            this_line = lines[n].line;
-            sol = lines[n].position;
-            eol = text.length();
-          } else {
-            this_line = "";
-            sol = -1;
-            eol = text.length();
-          }
-          y = ez.canvas.top() + remainder * 0.7 + (n - offset) * per_line_h;
-          x = ez.theme->tb_hmargin;
-          if (!readonly && sol != -1 && cursor_pos >= sol && cursor_pos <= eol
-              && n < lines.size()) {  // if cursor is on current line
-            x += M5.Lcd.drawString(this_line.substring(0, cursor_pos - sol), x, y);
-            cursor_x = x;
-            cursor_y = y;
-            x += cursor_width;
-            x += M5.Lcd.drawString(this_line.substring(cursor_pos - sol), x, y);
-          } else {
-            x += M5.Lcd.drawString(this_line, x, y);
-          }
-          M5.Lcd.fillRect(x, y, ez.canvas.width() - x, per_line_h, ez.screen.background());
-        }
-        redraw = false;
-      }
-    }
-    if (!readonly && cursor_x && cursor_y
-        && millis() - cursor_time > ez.theme->input_cursor_blink) {
-      cursor_time = millis();
-      if (cursor_state) {
-        M5.Lcd.fillRect(cursor_x, cursor_y, cursor_width, cursor_height, ez.screen.background());
-        cursor_state = false;
-      } else {
-        M5.Lcd.fillRect(cursor_x, cursor_y, cursor_width, cursor_height, color);
-        cursor_state = true;
-      }
-    }
-    String key = ez.buttons.poll();
-#ifdef M5EZ_FACES
-    if (ez.faces.on() && key == "")
-      key = ez.faces.poll();
-#endif
-    if (key == "down") {
-      offset += lines_per_screen;
-      ez.canvas.clear();
-      redraw = true;
-      key = "";
-    }
-    if (key == "up") {
-      offset -= lines_per_screen;
-      ez.canvas.clear();
-      redraw = true;
-      key = "";
-    }
-    if (key == "Done") {
-      ez.screen.clear();
-      return text;
-    }
-    if (key == (String) char(8)) {  // Delete
-      if (cursor_pos > 0) {
-        text = text.substring(0, cursor_pos - 1) + text.substring(cursor_pos);
-        cursor_pos--;
-        _wrapLines(text, ez.canvas.width() - 2 * ez.theme->tb_hmargin, lines);
-        redraw = true;
-      }
-      key = "";
-    }
-    if (key == (String) char(191)) {  // left arrow on FACES keyboard
-      if (cursor_pos > 0) {
-        cursor_pos--;
-        redraw = true;
-      }
-      key = "";
-    }
-    if (key == (String) char(193)) {  // right arrow on FACES keyboard
-      if (cursor_pos < text.length()) {
-        cursor_pos++;
-        redraw = true;
-      }
-      key = "";
-    }
-    if (key == (String) char(183)
-        || key == (String) char(192)) {  // up or down arrow on FACES keyboard
-      uint16_t cursor_line = lines.size() - 1;
-      for (uint16_t n = 0; n < lines.size(); n++) {
-        if (cursor_pos < lines[n].position) {
-          cursor_line = n - 1;
-          break;
-        }
-      }
-      float relative_pos =
-          (float)(cursor_pos - lines[cursor_line].position) / lines[cursor_line].line.length();
-      if (key == (String) char(183)) {  // up
-        if (cursor_line >= 1) {
-          cursor_pos =
-              lines[cursor_line - 1].position + lines[cursor_line - 1].line.length() * relative_pos;
-          redraw = true;
-        }
-      } else {  // down
-        if (cursor_line < lines.size() - 1) {
-          cursor_pos =
-              lines[cursor_line + 1].position + lines[cursor_line + 1].line.length() * relative_pos;
-          redraw = true;
-        }
-      }
-      key = "";
-    }
-
-    if (!readonly) {
-      if (key >= " " && key <= "~") {
-        if (cursor_pos == text.length()) {
-          text = text + key;
-        } else {
-          text = text.substring(0, cursor_pos) + key + text.substring(cursor_pos);
-        }
-        cursor_pos++;
-        _wrapLines(text, ez.canvas.width() - 2 * ez.theme->tb_hmargin, lines);
-        redraw = true;
-      }
-    }
-  }
-}
-
-void M5ez::_wrapLines(String text, uint16_t width, std::vector<line_t> &lines) {
-  lines.clear();
-  int16_t offset = 0;
-  int16_t last_space = 0;
-  int16_t cur_space = 0;
-  int16_t newline = 0;
-  bool all_done = false;
-  line_t new_line;
-
-  // If there are no return chars, it's either a single line,
-  // Or it's using linux/mac line endings which are a single char
-  char nlchar = 13;
-  if (text.indexOf(13) == -1)
-    nlchar = 10;
-
-  while (!all_done) {
-    cur_space = text.indexOf(" ", last_space + 1);
-    if (cur_space == -1) {
-      cur_space = text.length();
-      all_done = true;
-    }
-    newline = text.indexOf(char(nlchar), last_space + 1);
-    if (newline != -1 && newline < cur_space)
-      cur_space = newline;
-    if (M5.Lcd.textWidth(text.substring(offset, cur_space)) > width
-        || text.substring(last_space, last_space + 1) == (String) char(nlchar)) {
-      if (M5.Lcd.textWidth(text.substring(offset, last_space)) <= width) {
-        new_line.position = offset;
-        new_line.line = text.substring(offset, last_space);
-        lines.push_back(new_line);
-        offset = last_space + 1;
-        last_space = cur_space;
-      } else {
-        for (uint16_t n = offset; n < text.length(); n++) {
-          if (M5.Lcd.textWidth(text.substring(offset, n + 1)) > width) {
-            new_line.position = offset;
-            new_line.line = text.substring(offset, n);
-            lines.push_back(new_line);
-            offset = n;
-            break;
-          }
-        }
-      }
-    } else {
-      last_space = cur_space;
-    }
-
-    // Special case handle the last line
-    if (all_done && offset < text.length()) {
-      while (text.indexOf(char(nlchar), offset) > offset) {
-        if (offset < text.length()) {
-          new_line.line = text.substring(offset, text.indexOf(char(nlchar), offset));
-          new_line.position = offset;
-          offset = text.indexOf(char(nlchar), offset);
-          lines.push_back(new_line);
-        } else {
-          break;
-        }
-      }
-    }
-
-    if (all_done && offset < text.length()) {
-      new_line.position = offset;
-      new_line.line = text.substring(offset);
-      lines.push_back(new_line);
-    }
-  }
-}
-
-void M5ez::_fitLines(String text,
+void M5ez::_fitLines(std::vector<std::string> text,
                      uint16_t max_width,
                      uint16_t min_width,
                      std::vector<line_t> &lines) {
-  uint8_t prev_num_lines = 100;
-  for (int16_t n = max_width; n > min_width; n -= 10) {
-    _wrapLines(text, n, lines);
-    if (lines.size() > prev_num_lines) {
-      _wrapLines(text, n + 10, lines);
-      return;
-    }
-    prev_num_lines = lines.size();
+  for (int16_t n = 0; n < text.size(); n++) {
+    line_t line = {n, text[n]};
+    lines.push_back(line);
   }
 }
 
-// Some generic String object helper functions. Made public because they might be useful in user
-// code
-
-String M5ez::rightOf(String input, String separator, bool trim /* = true */) {
-  input.replace("\\" + separator,
-                (String) char(255));  // allow for backslash escaping of the separator
-  int16_t sep_pos = input.indexOf(separator);
-  input.replace((String) char(255), separator);
-  String out = input.substring(sep_pos + 1);
-  if (trim)
-    out.trim();
-  return out;
-}
-
-String M5ez::leftOf(String input, String separator, bool trim /* = true */) {
-  input.replace("\\" + separator,
-                (String) char(255));  // allow for backslash escaping of the separator
-  int16_t sep_pos = input.indexOf(separator);
-  input.replace((String) char(255), separator);
-  if (sep_pos == -1)
-    sep_pos = input.length();
-  String out = input.substring(0, sep_pos);
-  if (trim)
-    out.trim();
-  return out;
-}
-
-int16_t M5ez::chopString(String input,
-                         String separator,
-                         std::vector<String> &chops,
-                         bool trim /* = true */) {
-  input.replace("\\" + separator,
-                (String) char(255));  // allow for backslash escaping of the separator
-  int16_t next_sep, offset = 0;
-  bool done = false;
-  while (!done) {
-    next_sep = input.indexOf(separator, offset);
-    if (next_sep == -1) {
-      next_sep = input.length();
-      done = true;
-    }
-    String chop = input.substring(offset, next_sep);
-    chop.replace((String) char(255), separator);
-    if (trim)
-      chop.trim();
-    chops.push_back(chop);
-    offset = next_sep + 1;
-  }
-  return chops.size();
-}
-
-int16_t M5ez::charsFit(String input, int16_t cutoff) {
-  int16_t measured;
-  for (int16_t n = input.length(); n >= 0; n--) {
-    measured = M5.Lcd.textWidth(input.substring(0, n));
-    if (measured <= cutoff) {
-      return n;
-    }
-  }
-  return 0;
-}
-
-String M5ez::clipString(String input, int16_t cutoff, bool dots /* = true */) {
-  if (M5.Lcd.textWidth(input) <= cutoff) {
+std::string M5ez::clipString(std::string input, int16_t cutoff, bool dots /* = true */) {
+  if (M5.Lcd.textWidth(input.c_str()) <= cutoff) {
     return input;
   } else {
     for (int16_t n = input.length(); n >= 0; n--) {
-      String toMeasure = input.substring(0, n);
+      std::string toMeasure = input.substr(0, n);
       if (dots)
         toMeasure = toMeasure + "..";
-      if (M5.Lcd.textWidth(toMeasure) <= cutoff)
+      if (M5.Lcd.textWidth(toMeasure.c_str()) <= cutoff)
         return toMeasure;
     }
     return "";
   }
 }
 
-bool M5ez::isBackExitOrDone(String str) {
+bool M5ez::isBackExitOrDone(std::string str) {
   if (str == "back" || str == "exit" || str == "done" || str == "Back" || str == "Exit"
       || str == "Done")
     return true;
@@ -2912,8 +1151,8 @@ int16_t M5ez::fontHeight() {
 #endif
 }
 
-String M5ez::version() {
-  return M5EZ_VERSION;
+std::string M5ez::version() {
+  return std::string(M5EZ_VERSION);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2923,12 +1162,12 @@ String M5ez::version() {
 //
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-ezMenu::ezMenu(String hdr /* = "" */) {
+ezMenu::ezMenu(std::string hdr /* = "" */) {
   _img_background = NO_COLOR;
   _offset = 0;
   _selected = -1;
   _header = hdr;
-  _buttons = "";
+  _buttons = {};
   _font = NULL;
   _img_from_top = 0;
   _img_caption_location = TC_DATUM;
@@ -2951,7 +1190,8 @@ void ezMenu::txtFont(const GFXfont *font) {
   _font = font;
 }
 
-bool ezMenu::addItem(String nameAndCaption,
+bool ezMenu::addItem(std::string name,
+                     std::string caption,
                      void (*simpleFunction)() /* = NULL */,
                      bool (*advancedFunction)(ezMenu *callingMenu) /* = NULL */,
                      void (*drawFunction)(ezMenu *callingMenu,
@@ -2959,25 +1199,7 @@ bool ezMenu::addItem(String nameAndCaption,
                                           int16_t y,
                                           int16_t w,
                                           int16_t h) /* = NULL */) {
-  return addItem(NULL, nameAndCaption, simpleFunction, advancedFunction, drawFunction);
-}
-
-bool ezMenu::addItem(const char *image,
-                     String nameAndCaption,
-                     void (*simpleFunction)() /* = NULL */,
-                     bool (*advancedFunction)(ezMenu *callingMenu) /* = NULL */,
-                     void (*drawFunction)(ezMenu *callingMenu,
-                                          int16_t x,
-                                          int16_t y,
-                                          int16_t w,
-                                          int16_t h) /* = NULL */) {
-  MenuItem_t new_item;
-  new_item.image = image;
-  new_item.fs = NULL;
-  new_item.nameAndCaption = nameAndCaption;
-  new_item.simpleFunction = simpleFunction;
-  new_item.advancedFunction = advancedFunction;
-  new_item.drawFunction = drawFunction;
+  MenuItem_t new_item = {name, caption, simpleFunction, advancedFunction, drawFunction};
   if (_selected == -1)
     _selected = _items.size();
   _items.push_back(new_item);
@@ -2985,24 +1207,6 @@ bool ezMenu::addItem(const char *image,
   M5ez::_redraw = true;
   return true;
 }
-
-#if 0
-bool ezMenu::addItem(fs::FS &fs, String path, String nameAndCaption, void (*simpleFunction)() /* = NULL */, bool (*advancedFunction)(ezMenu* callingMenu) /* = NULL */, void (*drawFunction)(ezMenu* callingMenu, int16_t x, int16_t y, int16_t w, int16_t h) /* = NULL */) {
-	MenuItem_t new_item;
-	new_item.image = NULL;
-	new_item.fs = &fs;
-	new_item.path = path;
-	new_item.nameAndCaption = nameAndCaption;
-	new_item.simpleFunction = simpleFunction;
-	new_item.advancedFunction = advancedFunction;
-	new_item.drawFunction = drawFunction;
-	if (_selected == -1) _selected = _items.size();
-	_items.push_back(new_item);
-	_sortItems();
-	M5ez::_redraw = true;
-	return true;
-}
-#endif
 
 bool ezMenu::deleteItem(int16_t index) {
   if (index < 1 || index > _items.size())
@@ -3016,34 +1220,29 @@ bool ezMenu::deleteItem(int16_t index) {
   return true;
 }
 
-bool ezMenu::deleteItem(String name) {
+bool ezMenu::deleteItem(std::string name) {
   return deleteItem(getItemNum(name));
+}
+
+bool ezMenu::setCaption(std::string name, std::string caption) {
+  auto item = std::find_if(_items.begin(), _items.end(),
+                           [&](const MenuItem_t &v) { return v.name == name; });
+  if (item != _items.end()) {
+    item->caption = caption;
+    M5ez::_redraw = true;
+    return true;
+  }
+
+  return false;
 }
 
 int16_t ezMenu::countItems(void) {
   return _items.size();
 }
 
-bool ezMenu::setCaption(int16_t index, String caption) {
-  if (index < 1 || index > _items.size())
-    return false;
-  index--;  // internally we work with zero-referenced items
-  String currentName = ez.leftOf(_items[index].nameAndCaption, "|");
-  String currentCaption = ez.rightOf(_items[index].nameAndCaption, "|");
-  _items[index].nameAndCaption = currentName + "|" + caption;
-  M5ez::_redraw = true;
-  return true;
-}
-
-bool ezMenu::setCaption(String name, String caption) {
-  return setCaption(getItemNum(name), caption);
-}
-
-int16_t ezMenu::getItemNum(String name) {
-  String itemName;
+int16_t ezMenu::getItemNum(std::string name) {
   for (int16_t n = 0; n < _items.size(); n++) {
-    itemName = ez.leftOf(_items[n].nameAndCaption, "|");
-    if (itemName == name)
+    if (_items[n].name == name)
       return n + 1;
   }
   return 0;
@@ -3054,24 +1253,24 @@ void ezMenu::setSortFunction(bool (*sortFunction)(const char *s1, const char *s2
   _sortItems();  // In case the menu is already populated
 }
 
-void ezMenu::buttons(String bttns) {
+void ezMenu::buttons(std::vector<std::string> bttns) {
   _buttons = bttns;
 }
 
-void ezMenu::upOnFirst(String nameAndCaption) {
-  _up_on_first = nameAndCaption;
+void ezMenu::upOnFirst(std::string name) {
+  _up_on_first = name;
 }
 
-void ezMenu::leftOnFirst(String nameAndCaption) {
-  _up_on_first = nameAndCaption;
+void ezMenu::leftOnFirst(std::string name) {
+  _up_on_first = name;
 }
 
-void ezMenu::downOnLast(String nameAndCaption) {
-  _down_on_last = nameAndCaption;
+void ezMenu::downOnLast(std::string name) {
+  _down_on_last = name;
 }
 
-void ezMenu::rightOnLast(String nameAndCaption) {
-  _down_on_last = nameAndCaption;
+void ezMenu::rightOnLast(std::string name) {
+  _down_on_last = name;
 }
 
 void ezMenu::run() {
@@ -3086,10 +1285,6 @@ int16_t ezMenu::runOnce(bool dynamic) {
     _selected = 0;
   if (!_font)
     _font = ez.theme->menu_big_font;  // Cannot be in constructor: ez.theme not there yet
-  for (int16_t n = 0; n < _items.size(); n++) {
-    if (_items[n].image != NULL || _items[n].fs != NULL)
-      return _runImagesOnce();
-  }
 
   int16_t r;
 
@@ -3101,8 +1296,8 @@ int16_t ezMenu::runOnce(bool dynamic) {
 }
 
 int16_t ezMenu::_runTextOnce(bool dynamic) {
-  if (_buttons == "")
-    _buttons = "up # select # down";
+  if (_buttons.size() == 0)
+    _buttons = {"up", "select", "down"};
   ez.screen.clear();
   if (_header != "")
     ez.header.show(_header);
@@ -3115,14 +1310,14 @@ int16_t ezMenu::_runTextOnce(bool dynamic) {
   while (true) {
     int16_t old_selected = _selected;
     int16_t old_offset = _offset;
-    String tmp_buttons = _buttons;
+    std::vector<std::string> tmp_buttons = _buttons;
     if (_selected <= 0)
-      tmp_buttons.replace("up", _up_on_first);
+      _replace(tmp_buttons, "up", _up_on_first);
     if (_selected >= _items.size() - 1)
-      tmp_buttons.replace("down", _down_on_last);
+      _replace(tmp_buttons, "down", _down_on_last);
     ez.buttons.show(tmp_buttons);
-    String name = ez.leftOf(_items[_selected].nameAndCaption, "|");
-    String pressed;
+    std::string name = _items[_selected].name;
+    std::string pressed;
     while (true) {
       pressed = ez.buttons.poll();
       if (M5ez::_redraw) {
@@ -3180,8 +1375,9 @@ int16_t ezMenu::_runTextOnce(bool dynamic) {
             this, ez.theme->menu_lmargin, top_item_h + (old_selected - _offset) * _per_item_h,
             TFT_W - ez.theme->menu_lmargin - ez.theme->menu_rmargin, _per_item_h);
       } else {
-        _drawItem(old_selected - _offset, ez.rightOf(_items[old_selected].nameAndCaption, "|"),
-                  false);
+        MenuItem_t *item = &_items[old_selected];
+        std::string text = item->caption != "" ? item->caption : item->name;
+        _drawItem(old_selected - _offset, text, false);
       };
       if (_items[_selected].drawFunction) {
         ez.setFont(_font);
@@ -3189,7 +1385,9 @@ int16_t ezMenu::_runTextOnce(bool dynamic) {
             this, ez.theme->menu_lmargin, top_item_h + (_selected - _offset) * _per_item_h,
             TFT_W - ez.theme->menu_lmargin - ez.theme->menu_rmargin, _per_item_h);
       } else {
-        _drawItem(_selected - _offset, ez.rightOf(_items[_selected].nameAndCaption, "|"), true);
+        MenuItem_t *item = &_items[_selected];
+        std::string text = item->caption != "" ? item->caption : item->name;
+        _drawItem(_selected - _offset, text, true);
       };
     } else {
       ez.canvas.clear();
@@ -3212,7 +1410,9 @@ void ezMenu::_drawItems() {
                                         TFT_W - ez.theme->menu_lmargin - ez.theme->menu_rmargin,
                                         _per_item_h);
       } else {
-        _drawItem(n, ez.rightOf(_items[item_ref].nameAndCaption, "|"), (item_ref == _selected));
+        MenuItem_t *item = &_items[item_ref];
+        std::string text = item->caption != "" ? item->caption : item->name;
+        _drawItem(n, text, (item_ref == _selected));
       }
     }
   }
@@ -3220,7 +1420,7 @@ void ezMenu::_drawItems() {
   M5ez::_redraw = false;
 }
 
-void ezMenu::_drawItem(int16_t n, String text, bool selected) {
+void ezMenu::_drawItem(int16_t n, std::string text, bool selected) {
   uint16_t fill_color;
   ez.setFont(_font);
   int16_t top_item_h =
@@ -3242,11 +1442,12 @@ void ezMenu::_drawItem(int16_t n, String text, bool selected) {
   M5.Lcd.fillRoundRect(ez.theme->menu_lmargin, top_item_h + n * _per_item_h,
                        TFT_W - ez.theme->menu_lmargin - ez.theme->menu_rmargin, _per_item_h,
                        ez.theme->menu_item_radius, fill_color);
-  M5.Lcd.drawString(ez.leftOf(text, "\t"), ez.theme->menu_lmargin + ez.theme->menu_item_hmargin,
-                    menu_text_y);
-  if (text.indexOf("\t") != -1) {
+  auto tabpos = text.find("\t");
+  M5.Lcd.drawString(text.substr(0, tabpos).c_str(),
+                    ez.theme->menu_lmargin + ez.theme->menu_item_hmargin, menu_text_y);
+  if (tabpos != std::string::npos) {
     M5.Lcd.setTextDatum(CR_DATUM);
-    M5.Lcd.drawString(ez.rightOf(text, "\t"),
+    M5.Lcd.drawString(text.substr(tabpos, std::string::npos).c_str(),
                       TFT_W - ez.theme->menu_rmargin - ez.theme->menu_item_hmargin, menu_text_y);
   }
 }
@@ -3281,87 +1482,9 @@ void ezMenu::imgCaptionMargins(int16_t margin) {
   _img_caption_vmargin = margin;
 }
 
-int16_t ezMenu::_runImagesOnce() {
-  if (_buttons == "")
-    _buttons = "left # select # right";
-  if (_img_background == NO_COLOR)
-    _img_background = ez.theme->background;
-  ez.screen.clear(_img_background);
-  String tmp_buttons = _buttons;
-  tmp_buttons.replace("left", "");
-  tmp_buttons.replace("right", "");
-  ez.buttons.show(tmp_buttons);
-  ez.screen.clear(_img_background);
-  if (_header != "")
-    ez.header.show(_header);
-  _drawImage(_items[_selected]);
-  _drawCaption();
-  while (true) {
-    tmp_buttons = _buttons;
-    if (_selected <= 0)
-      tmp_buttons.replace("left", "");
-    if (_selected >= _items.size() - 1)
-      tmp_buttons.replace("right", "");
-    ez.buttons.show(tmp_buttons);
-    String name = ez.leftOf(_items[_selected].nameAndCaption, "|");
-    String pressed;
-    while (true) {
-      pressed = ez.buttons.poll();
-      if (pressed != "")
-        break;
-    }
-    if (pressed == "left") {
-      _selected--;
-      ez.canvas.clear();
-      _drawImage(_items[_selected]);
-      _drawCaption();
-    } else if (pressed == "right") {
-      _selected++;
-      ez.canvas.clear();
-      _drawImage(_items[_selected]);
-      _drawCaption();
-    } else if ((ez.isBackExitOrDone(name) && !_items[_selected].advancedFunction)
-               || ez.isBackExitOrDone(pressed)) {
-      _pick_button = pressed;
-      _selected = -1;
-      ez.screen.clear();
-      return 0;
-    } else {
-      // Some other key must have been pressed. We're done here!
-      ez.screen.clear();
-      _pick_button = pressed;
-      if (_items[_selected].simpleFunction != NULL) {
-        (_items[_selected].simpleFunction)();
-        ez.screen.clear();
-      }
-      if (_items[_selected].advancedFunction != NULL) {
-        if (!(_items[_selected].advancedFunction)(this)) {
-          ez.screen.clear();
-          return 0;
-        } else {
-          ez.screen.clear();
-        }
-      }
-      return _selected
-             + 1;  // We return items starting at one, but work starting at zero internally
-    }
-  }
-}
-
-void ezMenu::_drawImage(MenuItem_t &item) {
-#if 0
-	if (item.image) {
-		M5.Lcd.drawJpg((uint8_t *)item.image, (sizeof(item.image) / sizeof(item.image[0])), 0, ez.canvas.top() + _img_from_top, TFT_W, ez.canvas.height() - _img_from_top);
-	}
-	if (item.fs) {
-		M5.Lcd.drawJpgFile(*(item.fs), item.path.c_str(), 0, ez.canvas.top() + _img_from_top, TFT_W, ez.canvas.height() - _img_from_top);
-	}
-#endif
-}
-
 void ezMenu::_drawCaption() {
   int16_t x, y;
-  String caption = ez.rightOf(_items[_selected].nameAndCaption, "|");
+  std::string caption = _items[_selected].caption;
   if (_img_caption_font == NULL || caption == "")
     return;
   ez.setFont(_img_caption_font);
@@ -3407,7 +1530,7 @@ void ezMenu::_drawCaption() {
       break;
       //
   }
-  M5.Lcd.drawString(caption, x, y);
+  M5.Lcd.drawString(caption.c_str(), x, y);
 }
 
 void ezMenu::_fixOffset() {
@@ -3432,16 +1555,8 @@ int16_t ezMenu::pick() {
   return _selected + 1;
 }
 
-String ezMenu::pickName() {
-  return ez.leftOf(_items[_selected].nameAndCaption, "|");
-}
-
-String ezMenu::pickCaption() {
-  return ez.rightOf(_items[_selected].nameAndCaption, "|");
-}
-
-String ezMenu::pickButton() {
-  return _pick_button;
+std::string ezMenu::pickName() {
+  return _items[_selected].name;
 }
 
 void ezMenu::_Arrows() {
@@ -3471,7 +1586,7 @@ void ezMenu::_Arrows() {
 
 bool ezMenu::_sortWrapper(MenuItem_t &item1, MenuItem_t &item2) {
   // Be sure to set _sortFunction before calling _sortWrapper(), as _sortItems ensures.
-  return _sortFunction(item1.nameAndCaption.c_str(), item2.nameAndCaption.c_str());
+  return _sortFunction(item1.name.c_str(), item2.name.c_str());
 }
 
 void ezMenu::_sortItems() {
@@ -3479,6 +1594,15 @@ void ezMenu::_sortItems() {
     using namespace std::placeholders;  // For _1, _2
     sort(_items.begin(), _items.end(), std::bind(&ezMenu::_sortWrapper, this, _1, _2));
     M5ez::_redraw = true;
+  }
+}
+
+void ezMenu::_replace(std::vector<std::string> &list, std::string name, std::string replacement) {
+  for (int i = 0; i < list.size(); i++) {
+    if (list[i] == name) {
+      list[i] = replacement;
+      return;
+    }
   }
 }
 
@@ -3527,9 +1651,9 @@ bool ezMenu::sort_dsc_caption_ci(const char *s1, const char *s2) {
 //
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-ezProgressBar::ezProgressBar(String header /* = "" */,
-                             String msg /* = "" */,
-                             String buttons /* = "" */,
+ezProgressBar::ezProgressBar(const std::string header /* = "" */,
+                             std::vector<std::string> msg /* = "" */,
+                             std::vector<std::string> buttons /* = "" */,
                              const GFXfont *font /* = NULL */,
                              uint16_t color /* = NO_COLOR */,
                              uint16_t bar_color /* = NO_COLOR */) {
@@ -3547,7 +1671,6 @@ ezProgressBar::ezProgressBar(String header /* = "" */,
     ez.header.show(header);
   ez.buttons.show(buttons);
   std::vector<line_t> lines;
-  msg.replace("|", (String) char(13));
   M5.Lcd.setTextDatum(CC_DATUM);
   M5.Lcd.setTextColor(color);
   ez.setFont(font);
@@ -3557,7 +1680,7 @@ ezProgressBar::ezProgressBar(String header /* = "" */,
   for (uint8_t n = 0; n < lines.size(); n++) {
     int16_t y =
         ez.canvas.top() + ez.canvas.height() / 2 - ((num_lines - 1) * font_h / 2) + n * font_h;
-    M5.Lcd.drawString(lines[n].line, TFT_W / 2, y);
+    M5.Lcd.drawString(lines[n].line.c_str(), TFT_W / 2, y);
   }
   _bar_y = ez.canvas.top() + ez.canvas.height() / 2 + ((num_lines - 1) * font_h / 2)
            - ez.theme->progressbar_width / 2;

--- a/lib/M5ez/src/M5ez.cpp
+++ b/lib/M5ez/src/M5ez.cpp
@@ -35,6 +35,7 @@ bool ezTheme::select(std::string name) {
       return true;
     }
   }
+
   return false;
 }
 
@@ -718,8 +719,7 @@ uint8_t ezBacklight::_brightness;
 uint8_t ezBacklight::_inactivity;
 uint32_t ezBacklight::_last_activity;
 uint8_t ezBacklight::_MinimumBrightness;
-uint8_t ezBacklight::_Step = 0;
-uint8_t ezBacklight::_MaxSteps = 8;
+const uint8_t ezBacklight::_MaxSteps;
 bool ezBacklight::_backlight_off = false;
 
 void ezBacklight::begin() {
@@ -758,8 +758,8 @@ void ezBacklight::menu() {
   blmenu.addItem("Inactivity timeout");
   blmenu.addItem("Back");
   blmenu.downOnLast("first");
-  _Step = (_brightness - _MinimumBrightness) * _MaxSteps
-          / (256 - _MinimumBrightness);  // Calculate step from brightness
+  uint8_t step = (_brightness - _MinimumBrightness) * _MaxSteps
+                 / (256 - _MinimumBrightness);  // Calculate step from brightness
   while (true) {
     switch (blmenu.runOnce()) {
       case 1: {
@@ -767,16 +767,16 @@ void ezBacklight::menu() {
         while (true) {
           std::string b = ez.buttons.poll();
           if (b == "Adjust") {
-            if (_brightness >= _MinimumBrightness && _Step < _MaxSteps - 1) {
-              _Step++;
+            if (_brightness >= _MinimumBrightness && step < _MaxSteps - 1) {
+              step++;
               _brightness =
-                  _MinimumBrightness + (_Step * (255 - _MinimumBrightness) / (_MaxSteps - 1));
+                  _MinimumBrightness + (step * (255 - _MinimumBrightness) / (_MaxSteps - 1));
             } else {
-              _Step = 0;
+              step = 0;
               _brightness = _MinimumBrightness;
             }
           }
-          float p = ((float)_Step / (_MaxSteps - 1)) * 100.0f;
+          float p = ((float)step / (_MaxSteps - 1)) * 100.0f;
           bl.value(p);
           M5.Display.setBrightness(_brightness);
           if (b == "Back")
@@ -1225,12 +1225,12 @@ bool ezMenu::deleteItem(std::string name) {
 }
 
 bool ezMenu::setCaption(std::string name, std::string caption) {
-  auto item = std::find_if(_items.begin(), _items.end(),
-                           [&](const MenuItem_t &v) { return v.name == name; });
-  if (item != _items.end()) {
-    item->caption = caption;
-    M5ez::_redraw = true;
-    return true;
+  for (int n = 0; n < _items.size(); n++) {
+    if (_items[n].name == name) {
+      _items[n].caption = caption;
+      M5ez::_redraw = true;
+      return true;
+    }
   }
 
   return false;

--- a/lib/M5ez/src/M5ez.h
+++ b/lib/M5ez/src/M5ez.h
@@ -460,8 +460,7 @@ class ezBacklight {
   static uint8_t _inactivity;
   static uint32_t _last_activity;
   static uint8_t _MinimumBrightness;
-  static uint8_t _Step;
-  static uint8_t _MaxSteps;
+  static const uint8_t _MaxSteps = 8;
   static bool _backlight_off;
   //
 };

--- a/lib/M5ez/src/M5ez.h
+++ b/lib/M5ez/src/M5ez.h
@@ -3,44 +3,15 @@
 
 #define M5EZ_VERSION "2.1.2"
 
-// Comment out the line below to disable WPS.
-#undef M5EZ_WPS
-
-// Turn this off to compile without WiFi (no) OTA updates, no clock)
-#undef M5EZ_WIFI
-
 // Turn this off if you don't have a battery attached
 #define M5EZ_BATTERY
-
-// Turn this off to compile without BLE (Bluetooth Low Energy)
-// #define M5EZ_BLE
-#ifdef M5EZ_BLE
-#define M5EZ_BLE_DEVICE_NAME "M5ez"
-#endif
-
-// Have the autoconnect logic print debug messages on the serial port
-// #define M5EZ_WIFI_DEBUG
 
 // Determines whether the backlight is settable
 #define M5EZ_BACKLIGHT
 
-// Compile in ezTime and create a settings menu for clock display
-#undef M5EZ_CLOCK
-
-// FACES settings menu
-#undef M5EZ_FACES
-
-#include <vector>  // std::vector
-#ifdef M5EZ_WIFI
-#include <WiFi.h>  // WiFiEvent_t, system_event_info_t
-#endif
-
 #include <FS.h>
 #include <M5Unified.h>
 
-#ifdef M5EZ_CLOCK
-#include <ezTime.h>  // events, on-screen clock
-#endif
 // Special fake font pointers to access the older non FreeFonts in a unified way.
 // Only valid if passed to ez.setFont
 // (Note that these need to be specified without the & in front, unlike the FreeFonts)
@@ -90,7 +61,7 @@
 
 struct line_t {
   int16_t position;
-  String line;
+  std::string line;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -104,10 +75,10 @@ class ezTheme {
  public:
   static void begin();
   void add();
-  static bool select(String name);
+  static bool select(std::string name);
   static void menu();
 
-  String name = "Default";  // Change this when making theme
+  std::string name = "Default";  // Change this when making theme
   uint16_t background = 0xEF7D;
   uint16_t foreground = TFT_BLACK;
   uint8_t header_height = TFT_HEADER_HEIGHT;
@@ -121,8 +92,6 @@ class ezTheme {
   uint16_t print_color = foreground;
 
   const GFXfont *clock_font = TFT_FONT;
-
-  uint16_t longpress_time = 250;  // milliseconds
 
   uint8_t button_height = TFT_BUTTON_HEIGHT;
   const GFXfont *button_font = TFT_FONT;
@@ -209,7 +178,7 @@ class ezScreen {
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 struct header_widget_t {
-  String name;
+  std::string name;
   bool leftover;  // widget gets all leftover width. Used by title, only one widget can have this
                   // property
   uint16_t x;
@@ -223,25 +192,25 @@ class ezHeader {
  private:
   static std::vector<header_widget_t> _widgets;
   static bool _shown;
-  static String _title;
+  static std::string _title;
   static void _drawTitle(uint16_t x, uint16_t w);
   static void _recalculate();
 
  public:
   static void begin();
-  static void show(String t = "");
+  static void show(std::string t = "");
   static bool shown();
   static void clear(bool wipe = true);
   static void insert(uint8_t position,
-                     String name,
+                     std::string name,
                      uint16_t width,
                      void (*function)(uint16_t x, uint16_t w),
                      bool leftover = false);
-  static void remove(String name);
-  static uint8_t position(String name);
-  static void draw(String name = "");
-  static String title();
-  static void title(String title);
+  static void remove(std::string name);
+  static uint8_t position(std::string name);
+  static void draw(std::string name = "");
+  static std::string title();
+  static void title(std::string title);
   //
 };
 
@@ -257,7 +226,7 @@ struct print_t {
   uint16_t color;
   uint16_t x;
   int16_t y;
-  String text;
+  std::string text;
 };
 
 class ezCanvas: public Print {
@@ -290,7 +259,7 @@ class ezCanvas: public Print {
   static uint8_t y();
   static void y(uint8_t newy);
   virtual size_t write(
-      uint8_t c);  // These three are used to inherint print and println from Print class
+      uint8_t c);  // These three are used to inherit print and println from Print class
   virtual size_t write(const char *str);
   virtual size_t write(const uint8_t *buffer, size_t size);
   static uint16_t loop(void *private_data);
@@ -305,8 +274,8 @@ class ezCanvas: public Print {
   static bool _wrap, _scroll;
   static const GFXfont *_font;
   static uint16_t _color;
-  static void _print(String text);
-  static void _putString(String text);
+  static void _print(std::string text);
+  static void _putString(std::string text);
   //
 };
 
@@ -320,30 +289,26 @@ class ezCanvas: public Print {
 class ezButtons {
  public:
   static void begin();
-  static void show(String buttons);
-  static String get();
+  static void show(std::vector<std::string> buttons);
+  static std::vector<std::string> get();
   static void clear(bool wipe = true);
   static void releaseWait();
-  static String poll();
-  static String wait(String Buttons = "");
+  static std::string poll();
+  static std::string wait();
 
  private:
-  static String _btn_a_s, _btn_a_l;
-  static String _btn_b_s, _btn_b_l;
-  static String _btn_c_s, _btn_c_l;
+  static std::string _btn_a;
+  static std::string _btn_b;
+  static std::string _btn_c;
   static bool _key_release_wait;
   static bool _lower_button_row, _upper_button_row;
-  static void _drawButtons(String btn_a_s,
-                           String btn_a_l,
-                           String btn_b_s,
-                           String btn_b_l,
-                           String btn_c_s,
-                           String btn_c_l,
-                           String btn_ab,
-                           String btn_bc,
-                           String btn_ac);
-  static void _drawButton(int16_t row, String text_s, String text_l, int16_t x, int16_t w);
-  static void _drawButtonString(String text, int16_t x, int16_t y, uint16_t color, int16_t datum);
+  static void _drawButtons(std::string btn_a, std::string btn_b, std::string btn_c);
+  static void _drawButton(int16_t row, std::string text, int16_t x, int16_t w);
+  static void _drawButtonString(std::string text,
+                                int16_t x,
+                                int16_t y,
+                                uint16_t color,
+                                int16_t datum);
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -355,39 +320,26 @@ class ezButtons {
 
 class ezMenu {
  public:
-  ezMenu(String hdr = "");
+  ezMenu(std::string hdr = "");
   bool addItem(
-      String nameAndCaption,
-      void (*simpleFunction)() = NULL,
-      bool (*advancedFunction)(ezMenu *callingMenu) = NULL,
-      void (*drawFunction)(ezMenu *callingMenu, int16_t x, int16_t y, int16_t w, int16_t h) = NULL);
-  bool addItem(
-      const char *image,
-      String nameAndCaption,
-      void (*simpleFunction)() = NULL,
-      bool (*advancedFunction)(ezMenu *callingMenu) = NULL,
-      void (*drawFunction)(ezMenu *callingMenu, int16_t x, int16_t y, int16_t w, int16_t h) = NULL);
-  bool addItem(
-      fs::FS &fs,
-      String path,
-      String nameAndCaption,
+      std::string name,
+      std::string caption = "",
       void (*simpleFunction)() = NULL,
       bool (*advancedFunction)(ezMenu *callingMenu) = NULL,
       void (*drawFunction)(ezMenu *callingMenu, int16_t x, int16_t y, int16_t w, int16_t h) = NULL);
   bool deleteItem(int16_t index);
-  bool deleteItem(String name);
+  bool deleteItem(std::string name);
+  bool setCaption(std::string name, std::string caption);
   int16_t countItems(void);
-  bool setCaption(int16_t index, String caption);
-  bool setCaption(String name, String caption);
   void setSortFunction(bool (*sortFunction)(const char *s1, const char *s2));
-  void buttons(String bttns);
-  void upOnFirst(String nameAndCaption);
-  void leftOnFirst(String nameAndCaption);
-  void downOnLast(String nameAndCaption);
-  void rightOnLast(String nameAndCaption);
-  int16_t getItemNum(String name);
+  void buttons(std::vector<std::string> bttns);
+  void upOnFirst(std::string name);
+  void leftOnFirst(std::string name);
+  void downOnLast(std::string name);
+  void rightOnLast(std::string name);
+  int16_t getItemNum(std::string name);
   int16_t pick();
-  String pickName(), pickCaption(), pickButton();
+  std::string pickName();
   void run();
   int16_t runOnce(bool dynamic = false);
   void txtBig();
@@ -412,10 +364,8 @@ class ezMenu {
 
  private:
   struct MenuItem_t {
-    String nameAndCaption;
-    const char *image;
-    fs::FS *fs;
-    String path;
+    std::string name;
+    std::string caption;
     void (*simpleFunction)();
     bool (*advancedFunction)(ezMenu *callingMenu);
     void (*drawFunction)(ezMenu *callingMenu, int16_t x, int16_t y, int16_t w, int16_t h);
@@ -423,19 +373,18 @@ class ezMenu {
   std::vector<MenuItem_t> _items;
   int16_t _selected, _offset;
   bool _redraw;
-  String _header, _buttons, _pick_button;
-  String _up_on_first, _down_on_last;
+  std::string _header, _pick_button;
+  std::vector<std::string> _buttons;
+  std::string _up_on_first, _down_on_last;
   int16_t _per_item_h, _vmargin;
   int16_t _items_per_screen;
   uint16_t _old_background;
-  void _drawImage(MenuItem_t &item);
   void _drawCaption();
   const GFXfont *_font;
-  int16_t _runImagesOnce();
   int16_t _runTextOnce(bool dynamic = false);
   void _fixOffset();
   void _drawItems();
-  void _drawItem(int16_t n, String text, bool selected);
+  void _drawItem(int16_t n, std::string text, bool selected);
   void _Arrows();
   int16_t _img_from_top;
   uint8_t _img_caption_location;
@@ -446,6 +395,7 @@ class ezMenu {
   bool (*_sortFunction)(const char *s1, const char *s2);
   void _sortItems();
   bool _sortWrapper(MenuItem_t &item1, MenuItem_t &item2);
+  void _replace(std::vector<std::string> &list, std::string name, std::string replacement);
   //
 };
 
@@ -458,9 +408,9 @@ class ezMenu {
 
 class ezProgressBar {
  public:
-  ezProgressBar(String header = "",
-                String msg = "",
-                String buttons = "",
+  ezProgressBar(const std::string header = "",
+                std::vector<std::string> msg = {""},
+                std::vector<std::string> buttons = {""},
                 const GFXfont *font = NULL,
                 uint16_t color = NO_COLOR,
                 uint16_t bar_color = NO_COLOR);
@@ -520,157 +470,6 @@ class ezBacklight {
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
-//   C L O C K
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-#ifdef M5EZ_CLOCK
-class ezClock {
- public:
-  static Timezone tz;
-  static void begin();
-  static void restart();
-  static void menu();
-  static uint16_t loop(void *private_data);
-  static void clear();
-  static void draw(uint16_t x, uint16_t w);
-  static bool waitForSync(const uint16_t timeout = 0);
-
- private:
-  static void _writePrefs();
-  static bool _on;
-  static String _timezone;
-  static bool _clock12;
-  static bool _am_pm;
-  static String _datetime;
-  static bool _starting;
-  //
-};
-#endif
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-//   F A C E S
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-#ifdef M5EZ_FACES
-class ezFACES {
- public:
-  static void begin();
-  static void menu();
-  static String poll();
-  static bool on();
-
- private:
-  static bool _on;
-  //
-};
-#endif
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-//   W I F I
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-#ifdef M5EZ_WIFI
-
-enum WifiState_t {
-  EZWIFI_NOT_INIT,
-  EZWIFI_WAITING,
-  EZWIFI_IDLE,
-  EZWIFI_SCANNING,
-  EZWIFI_CONNECTING,
-  EZWIFI_AUTOCONNECT_DISABLED
-};
-
-struct WifiNetwork_t {
-  String SSID;
-  String key;
-};
-
-class ezWifi {
- public:
-  static std::vector<WifiNetwork_t> networks;
-  static bool autoConnect;
-  static void begin();
-  static void add(String ssid, String key);
-  static bool remove(int8_t index);
-  static bool remove(String ssid);
-  static int8_t indexForSSID(String ssid);
-  static void readFlash();
-  static void writeFlash();
-  static void menu();
-  static uint16_t loop(void *private_data);
-  static bool update(String url, const char *root_cert, ezProgressBar *pb = NULL);
-  static String updateError();
-
- private:
-  static WifiState_t _state;
-  static uint8_t _current_from_scan;
-  static uint32_t _wait_until, _widget_time;
-  static void _drawWidget(uint16_t x, uint16_t w);
-  static bool _onOff(ezMenu *callingMenu);
-  static void _manageAutoconnects();
-  static bool _autoconnectSelected(ezMenu *callingMenu);
-  static void _askAdd();
-  static bool _connection(ezMenu *callingMenu);
-  static void _update_progress(int done, int total);
-  static String _update_err2str(uint8_t _error);
-  static ezProgressBar *_update_progressbar;
-  static String _update_error;
-#ifdef M5EZ_WPS
-  static void _WPShelper(WiFiEvent_t event, system_event_info_t info);
-  static WiFiEvent_t _WPS_event;
-  static String _WPS_pin;
-  static bool _WPS_new_event;
-#endif
-  //
-};
-
-#endif
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-//   B L E
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-#ifdef M5EZ_BLE
-
-class ezBLE {
- public:
-  static void begin();
-  static void readFlash();
-  static void writeFlash();
-  static void menu();
-  static void disconnect();
-  static class BLEClient *getClient(uint16_t index);
-  static uint16_t getClientCount();
-
- private:
-  static const std::vector<std::pair<uint16_t, String>> _gattUuids;
-  static bool _on;
-  static bool _initialized;
-  static std::vector<class BLEClient *> _clients;
-  static bool _scan(ezMenu *callingMenu);
-  static void _connect(class BLEAdvertisedDevice &device);
-  static bool _listClients(ezMenu *callingMenu);
-  static bool _showClient(class BLEClient *client);
-  static void _cleanup();
-  static void _refresh();
-  friend class M5ezClientCallback;
-};
-
-#endif
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
 //   B A T T E R Y
 //
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -680,9 +479,6 @@ class ezBLE {
 class ezBattery {
  public:
   static void begin();
-  static void readFlash();
-  static void writeFlash();
-  static void menu();
   static uint16_t loop(void *private_data);
   static uint8_t getTransformedBatteryLevel();
   static uint16_t getBatteryBarColor(uint8_t batteryLevel);
@@ -724,24 +520,11 @@ class M5ez {
   static ezButtons buttons;
   static constexpr ezButtons &b = buttons;
   static ezSettings settings;
-#ifdef M5EZ_WIFI
-  static ezWifi wifi;
-  static constexpr ezWifi &w = wifi;
-#endif
-#ifdef M5EZ_BLE
-  static ezBLE ble;
-#endif
 #ifdef M5EZ_BATTERY
   static ezBattery battery;
 #endif
 #ifdef M5EZ_BACKLIGHT
   static ezBacklight backlight;
-#endif
-#ifdef M5EZ_CLOCK
-  static ezClock clock;
-#endif
-#ifdef M5EZ_FACES
-  static ezFACES faces;
 #endif
 
   static void begin();
@@ -755,63 +538,31 @@ class M5ez {
   static void redraw();
 
   // ez.msgBox
-  static String msgBox(String header,
-                       String msg,
-                       String buttons = "OK",
-                       const bool blocking = true,
-                       const GFXfont *font = NULL,
-                       uint16_t color = NO_COLOR,
-                       const bool clear = true);
+  static std::string msgBox(std::string header,
+                            std::vector<std::string> msg,
+                            std::vector<std::string> buttons = {"OK"},
+                            const bool blocking = true,
+                            const GFXfont *font = NULL,
+                            uint16_t color = NO_COLOR,
+                            const bool clear = true);
 
-  // ez.textInput
-  static String textInput(String header = "", String defaultText = "");
-
-  // ez.textBox
-  static String textBox(String header = "",
-                        String text = "",
-                        bool readonly = false,
-                        String buttons = "up#Done#down",
-                        const GFXfont *font = NULL,
-                        uint16_t color = NO_COLOR);
-
-  // Generic String object helper functions
-  static String rightOf(String input, String separator, bool trim = true);
-  static String leftOf(String input, String separator, bool trim = true);
-  static int16_t countStringInString(String haystack, String needle);
-  static int16_t chopString(String input,
-                            String separator,
-                            std::vector<String> &chops,
-                            bool trim = true);
-  static int16_t charsFit(String input, int16_t cutoff);
-  static String clipString(String input, int16_t cutoff, bool dots = true);
-  static bool isBackExitOrDone(String str);
+  static std::string clipString(std::string input, int16_t cutoff, bool dots = true);
+  static bool isBackExitOrDone(std::string str);
 
   // m5.lcd wrappers that make fonts easier
   static void setFont(const GFXfont *font);
   static int16_t fontHeight();
 
-  static String version();
+  static std::string version();
 
  private:
   static std::vector<event_t> _events;
   static bool _redraw;
 
-  // ez.textInput
-  static int16_t _text_cursor_x, _text_cursor_y, _text_cursor_h, _text_cursor_w;
-  static bool _text_cursor_state;
-  static void _drawTextInputLockString(String text);
-  static void _drawTextInputBox(String text);
-  static void _textCursor();
-  static void _textCursor(bool state);
-  static long _text_cursor_millis;
-
-  // ez.textBox
-  static void _wrapLines(String text, uint16_t width, std::vector<line_t> &lines);
-  static void _fitLines(String text,
+  static void _fitLines(std::vector<std::string> text,
                         uint16_t max_width,
                         uint16_t min_width,
                         std::vector<line_t> &lines);
-  //
 };
 
 extern M5ez ez;

--- a/src/interval.cpp
+++ b/src/interval.cpp
@@ -58,7 +58,7 @@ static void display_interval_msg(interval_state_t state,
 
   if ((len > 0) && memcmp(prev_hms, hms, len)) {
     memcpy(prev_hms, hms, len);
-    ez.msgBox((String)statestr, (String)hms, "Stop", false, NULL, NO_COLOR, false);
+    ez.msgBox(statestr, {hms}, {"Stop"}, false, NULL, NO_COLOR, false);
   }
 }
 
@@ -139,7 +139,7 @@ static void do_interval(FurbleCtx *fctx, interval_t *interval) {
 
 void remote_interval(FurbleCtx *fctx) {
   ezMenu submenu(FURBLE_STR " - Interval");
-  submenu.buttons("OK#down");
+  submenu.buttons({"OK", "down"});
   submenu.addItem("Start");
   settings_add_interval_items(&submenu);
   submenu.addItem("Back");

--- a/src/spinner.cpp
+++ b/src/spinner.cpp
@@ -67,12 +67,12 @@ static void display_spinner(const char *title,
     }
   }
 
-  const char *buttons = "Adjust#Next";
+  std::vector<std::string> buttons = {"Adjust", "Next"};
   if (index == 0) {
-    buttons = "OK#Next";
+    buttons = {"OK", "Next"};
   }
 
-  ez.msgBox(title, (String)spin_row, buttons, false);
+  ez.msgBox(title, {spin_row}, buttons, false);
 }
 
 static void spinner_preset(const char *title, SpinValue *sv) {
@@ -226,8 +226,8 @@ void spinner_modify_value(const char *title, bool preset, SpinValue *sv) {
   }
 }
 
-String sv2str(SpinValue *sv) {
-  return String(sv->value) + unit2str[sv->unit];
+std::string sv2str(SpinValue *sv) {
+  return std::to_string(sv->value) + unit2str[sv->unit];
 }
 
 unsigned long sv2ms(SpinValue *sv) {


### PR DESCRIPTION
Remove all String use in M5ez. Whilst here, remove all unused/uncompiled code and try to further reduce code size.

The primary aim is to reduce reliance on the Arduino framework as a change to bare esp-idf and FreeRTOS may be desired/required in the future.