### PR TITLE
Migrate to FreeRTOS for UI and camera control.

### DIFF
--- a/include/furble_control.h
+++ b/include/furble_control.h
@@ -1,0 +1,19 @@
+#ifndef FURBLE_CONTROL_H
+#define FURBLE_CONTROL_H
+
+#include <Camera.h>
+
+#define CONTROL_CMD_QUEUE_LEN (32)
+
+typedef enum {
+  CONTROL_CMD_SHUTTER_PRESS,
+  CONTROL_CMD_SHUTTER_RELEASE,
+  CONTROL_CMD_FOCUS_PRESS,
+  CONTROL_CMD_FOCUS_RELEASE,
+  CONTROL_CMD_GPS_UPDATE
+} control_cmd_t;
+
+void control_update_gps(Furble::Camera::gps_t &gps, Furble::Camera::timesync_t &timesync);
+void control_task(void *param);
+
+#endif

--- a/include/furble_gps.h
+++ b/include/furble_gps.h
@@ -9,6 +9,6 @@ extern TinyGPSPlus furble_gps;
 extern bool furble_gps_enable;
 
 void furble_gps_init(void);
-void furble_gps_update_geodata(Furble::Camera *camera);
+void furble_gps_update(Furble::Camera *camera);
 
 #endif

--- a/include/furble_ui.h
+++ b/include/furble_ui.h
@@ -8,4 +8,6 @@ struct FurbleCtx {
   bool reconnected;
 };
 
+void vUITask(void *param);
+
 #endif

--- a/lib/M5ez/src/M5ez.cpp
+++ b/lib/M5ez/src/M5ez.cpp
@@ -743,9 +743,6 @@ void ezSettings::begin() {
 #ifdef M5EZ_BATTERY
   ez.battery.begin();
 #endif
-#ifdef M5EZ_CLOCK
-  ez.clock.begin();
-#endif
 #ifdef M5EZ_BACKLIGHT
   ez.backlight.begin();
 #endif
@@ -1075,9 +1072,6 @@ void M5ez::yield() {
       }
     }
   }
-#ifdef M5EZ_CLOCK
-  events();  // TMP
-#endif
 }
 
 void M5ez::addEvent(uint16_t (*function)(void *private_data),

--- a/lib/furble/Camera.cpp
+++ b/lib/furble/Camera.cpp
@@ -24,6 +24,14 @@ bool Camera::connect(esp_power_level_t power, progressFunc pFunc, void *pCtx) {
   return connected;
 }
 
+bool Camera::isActive(void) {
+  return m_Active;
+}
+
+void Camera::setActive(bool active) {
+  m_Active = active;
+}
+
 const char *Camera::getName(void) {
   return m_Name.c_str();
 }

--- a/lib/furble/Camera.h
+++ b/lib/furble/Camera.h
@@ -87,6 +87,16 @@ class Camera {
    */
   virtual bool isConnected(void);
 
+  /**
+   * Camera is active (ie. connect() has succeeded previously).
+   */
+  bool isActive(void);
+
+  /**
+   * Set camera activity state.
+   */
+  void setActive(bool active);
+
   const char *getName(void);
 
   void fillSaveName(char *name);
@@ -115,6 +125,8 @@ class Camera {
   const uint16_t m_Latency = 1;
   // double the disconnect timeout
   const uint16_t m_Timeout = (2 * BLE_GAP_INITIAL_SUPERVISION_TIMEOUT);
+
+  bool m_Active = false;
 };
 }  // namespace Furble
 

--- a/src/furble_control.cpp
+++ b/src/furble_control.cpp
@@ -1,0 +1,58 @@
+#include <CameraList.h>
+
+#include "furble_control.h"
+
+static QueueHandle_t queue;
+
+static Furble::Camera::gps_t last_gps;
+static Furble::Camera::timesync_t last_timesync;
+
+void control_update_gps(Furble::Camera::gps_t &gps, Furble::Camera::timesync_t &timesync) {
+  last_gps = gps;
+  last_timesync = timesync;
+
+  control_cmd_t cmd = CONTROL_CMD_GPS_UPDATE;
+  xQueueSend(queue, &cmd, sizeof(control_cmd_t));
+}
+
+void control_task(void *param) {
+  queue = static_cast<QueueHandle_t>(param);
+
+  while (true) {
+    control_cmd_t cmd;
+    BaseType_t ret = xQueueReceive(queue, &cmd, pdMS_TO_TICKS(50));
+    if (ret == pdTRUE) {
+      for (size_t n = 0; n < Furble::CameraList::size(); n++) {
+        Furble::Camera *camera = Furble::CameraList::get(n);
+        if (!camera->isActive()) {
+          continue;
+        }
+
+        switch (cmd) {
+          case CONTROL_CMD_SHUTTER_PRESS:
+            camera->shutterPress();
+            ESP_LOGI(LOG_TAG, "shutterPress()");
+            break;
+          case CONTROL_CMD_SHUTTER_RELEASE:
+            ESP_LOGI(LOG_TAG, "shutterRelease()");
+            camera->shutterRelease();
+            break;
+          case CONTROL_CMD_FOCUS_PRESS:
+            ESP_LOGI(LOG_TAG, "focusPress()");
+            camera->focusPress();
+            break;
+          case CONTROL_CMD_FOCUS_RELEASE:
+            ESP_LOGI(LOG_TAG, "focusRelease()");
+            camera->focusRelease();
+            break;
+          case CONTROL_CMD_GPS_UPDATE:
+            ESP_LOGI(LOG_TAG, "updateGeoData()");
+            camera->updateGeoData(last_gps, last_timesync);
+            break;
+          default:
+            ESP_LOGE(LOG_TAG, "Invalid control command %d.", cmd);
+        }
+      }
+    }
+  }
+}

--- a/src/furble_gps.cpp
+++ b/src/furble_gps.cpp
@@ -3,6 +3,7 @@
 #include <M5ez.h>
 #include <TinyGPS++.h>
 
+#include "furble_control.h"
 #include "furble_gps.h"
 #include "settings.h"
 
@@ -51,7 +52,7 @@ static uint16_t service_grove_gps(void *private_data) {
 /**
  * Update geotag data.
  */
-void furble_gps_update_geodata(Furble::Camera *camera) {
+void furble_gps_update(Furble::Camera *camera) {
   if (!furble_gps_enable) {
     return;
   }
@@ -65,7 +66,7 @@ void furble_gps_update_geodata(Furble::Camera *camera) {
                                            furble_gps.date.day(),    furble_gps.time.hour(),
                                            furble_gps.time.minute(), furble_gps.time.second()};
 
-    camera->updateGeoData(dgps, timesync);
+    control_update_gps(dgps, timesync);
     ez.header.draw("gps");
   }
 }

--- a/src/interval.cpp
+++ b/src/interval.cpp
@@ -86,7 +86,6 @@ static void do_interval(FurbleCtx *fctx, interval_t *interval) {
 
   do {
     ez.yield();
-    furble_gps_update_geodata(camera);
     now = millis();
 
     if (fctx->reconnected) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,42 @@
+#include <Arduino.h>
+#include <freertos/FreeRTOS.h>
+
+#include "nimconfig.h"
+
+#include "Device.h"
+#include "Furble.h"
+
+#include "furble_control.h"
+#include "furble_ui.h"
+#include "settings.h"
+
+void setup() {
+  BaseType_t xRet;
+  TaskHandle_t xControlHandle = NULL;
+  TaskHandle_t xUIHandle = NULL;
+
+  Serial.begin(115200);
+
+  QueueHandle_t queue = xQueueCreate(CONTROL_CMD_QUEUE_LEN, sizeof(control_cmd_t));
+  if (queue == NULL) {
+    ESP_LOGE(LOG_TAG, "Failed to create control queue.");
+    abort();
+  }
+
+  Furble::Device::init();
+  Furble::Scan::init(settings_load_esp_tx_power());
+
+  xRet = xTaskCreatePinnedToCore(control_task, "control", 8192, queue, 3, &xControlHandle, 1);
+  if (xRet != pdPASS) {
+    ESP_LOGE(LOG_TAG, "Failed to create control task.");
+    abort();
+  }
+
+  xRet = xTaskCreatePinnedToCore(vUITask, "UI-M5ez", 32768, queue, 2, &xUIHandle, 1);
+  if (xRet != pdPASS) {
+    ESP_LOGE(LOG_TAG, "Failed to create UI task.");
+    abort();
+  }
+}
+
+void loop() {}

--- a/src/spinner.cpp
+++ b/src/spinner.cpp
@@ -149,7 +149,6 @@ static void spinner_preset(const char *title, SpinValue *sv) {
     }
 
     ez.yield();
-    delay(50);
   } while (!ok);
 
   // reconstruct the value


### PR DESCRIPTION
Still using the Arduino framework, however we now use the underlying FreeRTOS for better control over tasks.

Initially, split the UI and control to separate tasks, furthermore, use a queue to manage camera control.
This almost allows the UI to operate without constraints on camera traffic.