### PR TITLE
Minor cleanup of Canon EOS M6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Currently supported features in `furble`:
 | Scanning & Pairing | ✔️ | ✔️ | ✔️ | ✔️ |
 | Shutter Release | ✔️ | ✔️ | ✔️ | ✔️ |
 | Focus | ✔️ (see [#99](https://github.com/gkoh/furble/discussions/99)) | :x: | :x: (see [#29](https://github.com/gkoh/furble/issues/29)) | :x: |
-| GPS location tagging | ✔️ | :x: | :x: | :x: |
+| GPS location tagging | ✔️ | :x: (WiFi only) | :x: | :x: |
 
 ## Installation
 

--- a/lib/furble/CanonEOS.cpp
+++ b/lib/furble/CanonEOS.cpp
@@ -142,11 +142,6 @@ bool CanonEOS::connect(progressFunc pFunc, void *pCtx) {
 
   ESP_LOGI(LOG_TAG, "Identifying 5!");
 
-  /* write to 0xf204 */
-  x = 0x0a;
-  if (!write_value(m_Client, CANON_EOS_SVC_UNK0_UUID, CANON_EOS_CHR_UNK0_UUID, &x, 1))
-    return false;
-
   // Give the user 60s to confirm/deny pairing
   ESP_LOGI(LOG_TAG, "Waiting for user to confirm/deny pairing.");
   for (unsigned int i = 0; i < 60; i++) {
@@ -164,6 +159,8 @@ bool CanonEOS::connect(progressFunc pFunc, void *pCtx) {
     return false;
   }
 
+  ESP_LOGI(LOG_TAG, "Paired!");
+
   /* write to 0xf104 */
   x = 0x01;
   if (!write_value(m_Client, CANON_EOS_SVC_IDEN_UUID, CANON_EOS_CHR_IDEN_UUID, &x, 1))
@@ -171,14 +168,13 @@ bool CanonEOS::connect(progressFunc pFunc, void *pCtx) {
 
   updateProgress(pFunc, pCtx, 80.0f);
 
-  ESP_LOGI(LOG_TAG, "Identifying 6!");
+  ESP_LOGI(LOG_TAG, "Switching mode!");
 
   /* write to 0xf307 */
-  x = 0x03;
-  if (!write_value(m_Client, CANON_EOS_SVC_UNK1_UUID, CANON_EOS_CHR_UNK1_UUID, &x, 1))
+  if (!write_value(m_Client, CANON_EOS_SVC_MODE_UUID, CANON_EOS_CHR_MODE_UUID, &CANON_EOS_MODE_SHOOT, sizeof(CANON_EOS_MODE_SHOOT)))
     return false;
 
-  ESP_LOGI(LOG_TAG, "Paired!");
+  ESP_LOGI(LOG_TAG, "Done!");
   updateProgress(pFunc, pCtx, 100.0f);
 
   return true;

--- a/lib/furble/CanonEOS.cpp
+++ b/lib/furble/CanonEOS.cpp
@@ -171,7 +171,8 @@ bool CanonEOS::connect(progressFunc pFunc, void *pCtx) {
   ESP_LOGI(LOG_TAG, "Switching mode!");
 
   /* write to 0xf307 */
-  if (!write_value(m_Client, CANON_EOS_SVC_MODE_UUID, CANON_EOS_CHR_MODE_UUID, &CANON_EOS_MODE_SHOOT, sizeof(CANON_EOS_MODE_SHOOT)))
+  if (!write_value(m_Client, CANON_EOS_SVC_MODE_UUID, CANON_EOS_CHR_MODE_UUID,
+                   &CANON_EOS_MODE_SHOOT, sizeof(CANON_EOS_MODE_SHOOT)))
     return false;
 
   ESP_LOGI(LOG_TAG, "Done!");

--- a/lib/furble/CanonEOS.h
+++ b/lib/furble/CanonEOS.h
@@ -28,13 +28,9 @@ class CanonEOS: public Camera {
   /** 0xf104 */
   const char *CANON_EOS_CHR_IDEN_UUID = "0001000a-0000-1000-0000-d8492fffa821";
 
-  const char *CANON_EOS_SVC_UNK0_UUID = "00020000-0000-1000-0000-d8492fffa821";
-  /** 0xf204 */
-  const char *CANON_EOS_CHR_UNK0_UUID = "00020002-0000-1000-0000-d8492fffa821";
-
-  const char *CANON_EOS_SVC_UNK1_UUID = "00030000-0000-1000-0000-d8492fffa821";
+  const char *CANON_EOS_SVC_MODE_UUID = "00030000-0000-1000-0000-d8492fffa821";
   /** 0xf307 */
-  const char *CANON_EOS_CHR_UNK1_UUID = "00030010-0000-1000-0000-d8492fffa821";
+  const char *CANON_EOS_CHR_MODE_UUID = "00030010-0000-1000-0000-d8492fffa821";
 
   const char *CANON_EOS_SVC_SHUTTER_UUID = "00030000-0000-1000-0000-d8492fffa821";
   /** 0xf311 */
@@ -42,6 +38,9 @@ class CanonEOS: public Camera {
 
   const uint8_t CANON_EOS_PAIR_ACCEPT = 0x02;
   const uint8_t CANON_EOS_PAIR_REJECT = 0x03;
+  uint8_t CANON_EOS_MODE_PLAYBACK = 0x01;
+  uint8_t CANON_EOS_MODE_SHOOT = 0x02;
+  uint8_t CANON_EOS_MODE_WAKE = 0x03;
 
   bool write_value(NimBLEClient *pClient,
                    const char *serviceUUID,


### PR DESCRIPTION
Remove unneeded WiFi handshake.
Clarify GPS only works over WiFi for this model.