### PR TITLE
Implement infinite reconnect and cancel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ To use:
 
 WARNING:
 * this will not be kind to battery life
-* You must Forceful power off by holding the power button
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ To use:
 
 WARNING:
 * this will not be kind to battery life
-* You must use the power button to shut down
+* You must Forceful power off by holding the power button
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,19 @@ WARNING:
 * mobile device connections are extremely finnicky
 * multi-connect involving mobile devices is not well tested and can easily crash
 
+### Infinite-ReConnect
+
+This is useful for using furble as a passive, always on GPS data source.
+With this, the camera will attempt to reconnect indefinitely.
+You don't need to turn on this setting if you are actively using furble.
+
+To use:
+* Enable `Settings->Infinite-ReConnect`
+
+WARNING:
+* this will not be kind to battery life
+* You must use the power button to shut down
+
 ## Motivation
 
 I found current smartphone apps for basic wireless remote shutter control to be

--- a/include/furble_control.h
+++ b/include/furble_control.h
@@ -12,6 +12,7 @@ typedef enum {
   CONTROL_CMD_FOCUS_PRESS,
   CONTROL_CMD_FOCUS_RELEASE,
   CONTROL_CMD_GPS_UPDATE,
+  CONTROL_CMD_CONNECT,
   CONTROL_CMD_DISCONNECT,
   CONTROL_CMD_ERROR
 } control_cmd_t;
@@ -28,10 +29,9 @@ class Control {
     Camera *getCamera(void);
     control_cmd_t getCommand(void);
     void sendCommand(control_cmd_t cmd);
-    const Camera::gps_t &getGPS(void);
-    const Camera::timesync_t &getTimesync(void);
-
     void updateGPS(Camera::gps_t &gps, Camera::timesync_t &timesync);
+
+    void task(void);
 
    private:
     QueueHandle_t m_Queue = NULL;
@@ -61,12 +61,17 @@ class Control {
   /**
    * Are all active cameras still connected?
    */
-  bool isConnected(void);
+  bool allConnected(void);
 
   /**
    * Get list of connected targets.
    */
   const std::vector<std::unique_ptr<Control::Target>> &getTargets(void);
+
+  /**
+   * Connect to the specified camera.
+   */
+  void connect(Camera *, esp_power_level_t power);
 
   /**
    * Disconnect all connected cameras.
@@ -81,6 +86,10 @@ class Control {
  private:
   QueueHandle_t m_Queue = NULL;
   std::vector<std::unique_ptr<Control::Target>> m_Targets;
+
+  // Camera connects are serialised, the following track the last attempt
+  Camera *m_ConnectCamera = nullptr;
+  esp_power_level_t m_Power;
 };
 
 };  // namespace Furble

--- a/include/furble_ui.h
+++ b/include/furble_ui.h
@@ -5,7 +5,7 @@
 
 struct FurbleCtx {
   Furble::Control *control;
-  bool reconnected;
+  bool cancelled;
 };
 
 void vUITask(void *param);

--- a/include/settings.h
+++ b/include/settings.h
@@ -9,6 +9,9 @@
 void settings_menu_tx_power(void);
 esp_power_level_t settings_load_esp_tx_power(void);
 
+bool settings_load_reconnect(void);
+void settings_save_reconnect(bool reconnect);
+
 bool settings_load_gps(void);
 void settings_menu_gps(void);
 

--- a/lib/M5ez/src/M5ez.cpp
+++ b/lib/M5ez/src/M5ez.cpp
@@ -1058,10 +1058,14 @@ void M5ez::begin() {
   ez.settings.begin();
 }
 
-void M5ez::yield() {
+void M5ez::yield(bool events) {
   vTaskDelay(1);  // allow lower priority tasks to run
   ::yield();      // execute the Arduino yield in the root namespace
   M5.update();
+  if (!events) {
+    return;
+  }
+
   for (uint8_t n = 0; n < _events.size(); n++) {
     if (millis() > _events[n].when) {
       uint16_t r = (_events[n].function)(_events[n].context);

--- a/lib/M5ez/src/M5ez.h
+++ b/lib/M5ez/src/M5ez.h
@@ -503,7 +503,7 @@ class M5ez {
 
   static void begin();
 
-  static void yield();
+  static void yield(bool events = true);
 
   static void addEvent(uint16_t (*function)(void *), void *context = nullptr, uint32_t when = 1);
   static void removeEvent(uint16_t (*function)(void *context));

--- a/lib/furble/Camera.cpp
+++ b/lib/furble/Camera.cpp
@@ -12,13 +12,16 @@ Camera::~Camera() {
   NimBLEDevice::deleteClient(m_Client);
 }
 
-bool Camera::connect(esp_power_level_t power, progressFunc pFunc, void *pCtx) {
+bool Camera::connect(esp_power_level_t power) {
   // try extending range by adjusting connection parameters
-  bool connected = this->connect(pFunc, pCtx);
+  bool connected = this->connect();
   if (connected) {
     // Set BLE transmit power after connection is established.
     NimBLEDevice::setPower(power);
     m_Client->updateConnParams(m_MinInterval, m_MaxInterval, m_Latency, m_Timeout);
+    m_Connected = true;
+  } else {
+    m_Connected = false;
   }
 
   return connected;
@@ -44,14 +47,12 @@ const NimBLEAddress &Camera::getAddress(void) const {
   return m_Address;
 }
 
-void Camera::updateProgress(progressFunc pFunc, void *ctx, float value) {
-  if (pFunc != nullptr) {
-    (pFunc)(ctx, value);
-  }
+float Camera::getConnectProgress(void) const {
+  return m_Progress.load();
 }
 
 bool Camera::isConnected(void) const {
-  return m_Client->isConnected();
+  return m_Connected && m_Client->isConnected();
 }
 
 }  // namespace Furble

--- a/lib/furble/Camera.h
+++ b/lib/furble/Camera.h
@@ -1,6 +1,8 @@
 #ifndef CAMERA_H
 #define CAMERA_H
 
+#include <atomic>
+
 #include <NimBLEAddress.h>
 #include <NimBLEClient.h>
 #include <NimBLEDevice.h>
@@ -8,9 +10,6 @@
 #include "FurbleTypes.h"
 
 #define MAX_NAME (64)
-
-// Progress update function
-typedef void(progressFunc(void *, float));
 
 namespace Furble {
 
@@ -55,7 +54,7 @@ class Camera {
   /**
    * Wrapper for protected pure virtual Camera::connect().
    */
-  bool connect(esp_power_level_t power, progressFunc pFunc = nullptr, void *pCtx = nullptr);
+  bool connect(esp_power_level_t power);
 
   /**
    * Disconnect from the target.
@@ -111,8 +110,11 @@ class Camera {
 
   const NimBLEAddress &getAddress(void) const;
 
+  float getConnectProgress(void) const;
+
  protected:
   Camera(Type type);
+  std::atomic<float> m_Progress;
 
   /**
    * Connect to the target camera such that it is ready for shutter control.
@@ -122,13 +124,12 @@ class Camera {
    *
    * @return true if the client is now ready for shutter control
    */
-  virtual bool connect(progressFunc pFunc = nullptr, void *pCtx = nullptr) = 0;
+  virtual bool connect(void) = 0;
 
   NimBLEAddress m_Address = NimBLEAddress{};
   NimBLEClient *m_Client;
   std::string m_Name;
-
-  void updateProgress(progressFunc pFunc, void *ctx, float value);
+  bool m_Connected = false;
 
  private:
   const uint16_t m_MinInterval = BLE_GAP_INITIAL_CONN_ITVL_MIN;

--- a/lib/furble/CanonEOS.h
+++ b/lib/furble/CanonEOS.h
@@ -55,7 +55,7 @@ class CanonEOS: public Camera {
                     uint8_t *data,
                     size_t length);
 
-  bool connect(progressFunc pFunc = nullptr, void *pCtx = nullptr) override;
+  bool connect(void) override;
   void shutterPress(void) override;
   void shutterRelease(void) override;
   void focusPress(void) override;

--- a/lib/furble/Fujifilm.h
+++ b/lib/furble/Fujifilm.h
@@ -22,7 +22,7 @@ class Fujifilm: public Camera {
    */
   static bool matches(const NimBLEAdvertisedDevice *pDevice);
 
-  bool connect(progressFunc pFunc = nullptr, void *pCtx = nullptr) override;
+  bool connect(void) override;
   void shutterPress(void) override;
   void shutterRelease(void) override;
   void focusPress(void) override;
@@ -58,6 +58,7 @@ class Fujifilm: public Camera {
 
   void print(void);
   void notify(NimBLERemoteCharacteristic *, uint8_t *, size_t, bool);
+  bool subscribe(const NimBLEUUID &svc, const NimBLEUUID &chr, bool notifications);
   void sendGeoData(const gps_t &gps, const timesync_t &timesync);
 
   template <std::size_t N>

--- a/lib/furble/MobileDevice.h
+++ b/lib/furble/MobileDevice.h
@@ -18,7 +18,7 @@ class MobileDevice: public Camera {
 
   static bool matches(NimBLEAdvertisedDevice *pDevice);
 
-  bool connect(progressFunc pFunc = nullptr, void *pCtx = nullptr) override;
+  bool connect(void) override;
   void shutterPress(void) override;
   void shutterRelease(void) override;
   void focusPress(void) override;

--- a/src/furble.cpp
+++ b/src/furble.cpp
@@ -420,10 +420,25 @@ static bool multiconnect_toggle(ezMenu *menu, void *context) {
   return true;
 }
 
+/**
+ * Toggle Infinite-ReConnect menu setting.
+ */
+static bool reconnect_toggle(ezMenu *menu, void *context) {
+  bool *reconnect = static_cast<bool *>(context);
+  *reconnect = !*reconnect;
+  menu->setCaption("reconnectonoff",
+                   std::string("Infinite-ReConnect\t") + (*reconnect ? "ON" : "OFF"));
+
+  settings_save_reconnect(*reconnect);
+
+  return true;
+}
+
 static void menu_settings(void) {
   ezMenu submenu(FURBLE_STR " - Settings");
 
   bool multiconnect = settings_load_multiconnect();
+  bool reconnect = settings_load_reconnect();
 
   submenu.buttons({"OK", "down"});
   submenu.addItem("Backlight", "", ez.backlight.menu);
@@ -432,6 +447,9 @@ static void menu_settings(void) {
   submenu.addItem("multiconnectonoff",
                   std::string("Multi-Connect\t") + (multiconnect ? "ON" : "OFF"), nullptr,
                   &multiconnect, multiconnect_toggle);
+  submenu.addItem("reconnectonoff",
+                  std::string("Infinite-ReConnect\t") + (reconnect ? "ON" : "OFF"), nullptr,
+                  &reconnect, reconnect_toggle);
   submenu.addItem("Theme", "", ez.theme->menu);
   submenu.addItem("Transmit Power", "", settings_menu_tx_power);
   submenu.addItem("About", "", about);

--- a/src/interval.cpp
+++ b/src/interval.cpp
@@ -88,8 +88,8 @@ static void do_interval(FurbleCtx *fctx, const interval_t &interval) {
     ez.yield();
     now = millis();
 
-    if (fctx->reconnected) {
-      fctx->reconnected = false;
+    if (fctx->cancelled) {
+      break;
     }
 
     switch (state) {
@@ -135,7 +135,7 @@ static void do_interval(FurbleCtx *fctx, const interval_t &interval) {
     }
 
     display_interval_msg(state, icount, interval.count, now, next);
-  } while (active && control->isConnected());
+  } while (active && control->allConnected());
   ez.backlight.inactivity(USER_SET);
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -14,6 +14,7 @@ const char *PREFS_TX_POWER = "txpower";
 const char *PREFS_GPS = "gps";
 const char *PREFS_INTERVAL = "interval";
 const char *PREFS_MULTICONNECT = "multiconnect";
+const char *PREFS_RECONNECT = "reconnect";
 
 /**
  * Save BLE transmit power to preferences.
@@ -316,5 +317,23 @@ void settings_save_multiconnect(bool multiconnect) {
 
   prefs.begin(FURBLE_STR, false);
   prefs.putBool(PREFS_MULTICONNECT, multiconnect);
+  prefs.end();
+}
+
+bool settings_load_reconnect(void) {
+  Preferences prefs;
+
+  prefs.begin(FURBLE_STR, true);
+  bool reconnect = prefs.getBool(PREFS_RECONNECT, false);
+  prefs.end();
+
+  return reconnect;
+}
+
+void settings_save_reconnect(bool reconnect) {
+  Preferences prefs;
+
+  prefs.begin(FURBLE_STR, false);
+  prefs.putBool(PREFS_RECONNECT, reconnect);
   prefs.end();
 }


### PR DESCRIPTION
Enable a user to cancel a connection attempt.

Merge in #132 from @hijae for the settings to control the behaviour.

With this change, the following will occur:
* with `Infinite-ReConnect = OFF` 
   * `furble` will attempt a single reconnect on connection drop
   * a successful reconnect will reset the counter
* with `Infinite-ReConnect = ON`
   *  `furble` will attempt to reconnect indefinitely, unless `Cancel` is pressed
   * M5ez menu handling doesn't help us here, the control menu will be shown, but any item press will exit