### PR TITLE
Re-enable exceptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following devices have actually been tested and confirmed to work:
    - Fujifiml X-H1
    - Fujifilm X-H2S ([@val123456](https://github.com/val123456))
    - Fujifilm X-S10 ([@dimitrij2k](https://github.com/dimitrij2k))
+   - Fujifilm X-S20 ([@kelvincabaldo07](https://github.com/kelvincabaldo07))
    - Fujifilm X-T200 ([@Cronkan](https://github.com/Cronkan))
    - Fujifilm X-T30
    - Fujifilm X-T5 ([@stulevine](https://github.com/stulevine))

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,6 +1,5 @@
 [furble]
 build_flags = -Wall
-  -fno-exceptions
   -DFURBLE_VERSION=\"${sysenv.FURBLE_VERSION}\"
   -DCORE_DEBUG_LEVEL=3
   -DCONFIG_BT_NIMBLE_LOG_LEVEL=3


### PR DESCRIPTION
This is extra weird, disabling exceptions via compiler flags breaks new pairing with Fujifilm cameras.

I don't understand, re-enable for now.