### PR TITLE
Fix disconnect race crash.

### DIFF
--- a/include/FurbleControl.h
+++ b/include/FurbleControl.h
@@ -50,6 +50,8 @@ class Control {
    protected:
     Target(Camera *camera);
 
+    volatile bool m_Stopped = false;
+
    private:
     static constexpr UBaseType_t m_QueueLength = 8;
 


### PR DESCRIPTION
It was possible for the Target object to be destructed before it stopped.
This manifested as a crash when freed memory was accessed. Add a flag to wait and check.