### PR TITLE
Address UI issues in 3.0.0-rc2

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ During shutter control:
 * press and/or hold 'Focus' button to auto-focus
 * press and hold 'Shutter Lock' to lock shutter open
    * press and hold 'Shutter Lock' again to release
- 
+
 ### Menu Map
 
 * Connect (if connections are saved)
@@ -269,7 +269,7 @@ To use:
 
 A few basic themes are included, to change:
 * `Settings->Themes-><desired theme>`
-   * device will immediately restart to take effect
+   * hit 'Restart' to save and restart for the theme to take effect
    * better dynamic theme change support is improving in upstream LVGL
 
 ## Motivation

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ To use:
 
 A few basic themes are included, to change:
 * `Settings->Themes-><desired theme>`
-* `Settings->Themes->Restart` to fully set the theme
+   * device will immediately restart to take effect
    * better dynamic theme change support is improving in upstream LVGL
 
 ## Motivation

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -24,6 +24,11 @@ class UI {
   /** Check and/or handle inactivity. */
   void processInactivity(void);
 
+  /**
+   * Display/hide navigation bar.
+   */
+  static void displayNavigationBar(bool show);
+
   /** Configure shutter control. */
   void configShutterControl(void);
 
@@ -186,11 +191,11 @@ class UI {
   lv_obj_t *m_Root = nullptr;
   lv_obj_t *m_Header = nullptr;
   lv_obj_t *m_Content = nullptr;
-  lv_obj_t *m_NavBar = nullptr;
+  static lv_obj_t *m_NavBar;
 
-  lv_obj_t *m_Left = nullptr;
-  lv_obj_t *m_OK = nullptr;
-  lv_obj_t *m_Right = nullptr;
+  static lv_obj_t *m_Left;
+  static lv_obj_t *m_OK;
+  static lv_obj_t *m_Right;
 
   lv_obj_t *m_IntervalStart = nullptr;
   Intervalometer m_Intervalometer;

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -400,8 +400,8 @@
 #define LV_FONT_MONTSERRAT_16 1
 #define LV_FONT_MONTSERRAT_18 0
 #define LV_FONT_MONTSERRAT_20 0
-#define LV_FONT_MONTSERRAT_22 1
-#define LV_FONT_MONTSERRAT_24 0
+#define LV_FONT_MONTSERRAT_22 0
+#define LV_FONT_MONTSERRAT_24 1
 #define LV_FONT_MONTSERRAT_26 0
 #define LV_FONT_MONTSERRAT_28 0
 #define LV_FONT_MONTSERRAT_30 0
@@ -435,7 +435,7 @@
 #elif defined(FURBLE_M5STICKC_PLUS)
 #define LV_FONT_DEFAULT &lv_font_montserrat_16
 #elif defined(FURBLE_M5COREX)
-#define LV_FONT_DEFAULT &lv_font_montserrat_22
+#define LV_FONT_DEFAULT &lv_font_montserrat_24
 #endif
 
 /*Enable handling large font and/or fonts with a lot of characters.

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -1574,7 +1574,7 @@ void UI::addBacklightMenu(const menu_t &parent) {
 
   // Add brightness control
   lv_obj_t *label = lv_label_create(cont);
-  lv_label_set_text(label, "Backlight brightness");
+  lv_label_set_text(label, "Brightness");
   lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
   lv_obj_set_width(label, LV_PCT(100));
 

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -38,6 +38,11 @@ const uint32_t UI::m_KeyEnter;
 const uint32_t UI::m_KeyLeft;
 const uint32_t UI::m_KeyRight;
 
+lv_obj_t *UI::m_NavBar;
+lv_obj_t *UI::m_Left;
+lv_obj_t *UI::m_OK;
+lv_obj_t *UI::m_Right;
+
 bool UI::m_PMICHack;
 bool UI::m_PMICClicked;
 
@@ -858,6 +863,22 @@ void UI::addMainMenu(void) {
   lv_menu_set_page(m_MainMenu.main, m_MainMenu.page);
 }
 
+void UI::displayNavigationBar(bool show) {
+  if (!M5.Touch.isEnabled()) {
+    if (show) {
+      lv_obj_clear_flag(m_NavBar, LV_OBJ_FLAG_HIDDEN);
+      lv_obj_clear_flag(m_Left, LV_OBJ_FLAG_HIDDEN);
+      lv_obj_clear_flag(m_OK, LV_OBJ_FLAG_HIDDEN);
+      lv_obj_clear_flag(m_Right, LV_OBJ_FLAG_HIDDEN);
+    } else {
+      lv_obj_add_flag(m_NavBar, LV_OBJ_FLAG_HIDDEN);
+      lv_obj_add_flag(m_Left, LV_OBJ_FLAG_HIDDEN);
+      lv_obj_add_flag(m_OK, LV_OBJ_FLAG_HIDDEN);
+      lv_obj_add_flag(m_Right, LV_OBJ_FLAG_HIDDEN);
+    }
+  }
+}
+
 void UI::configShutterControl(void) {
   if (!M5.Touch.isEnabled()) {
     lv_obj_set_style_bg_image_src(m_Right, LV_SYMBOL_EYE_OPEN, 0);
@@ -929,6 +950,7 @@ void UI::connectTimerHandler(lv_timer_t *timer) {
         // hide menu, unhide message box
         lv_obj_add_flag(m_MainMenu.main, LV_OBJ_FLAG_HIDDEN);
         lv_obj_clear_flag(m_ConnectMessageBox, LV_OBJ_FLAG_HIDDEN);
+        UI::displayNavigationBar(false);
         lv_group_focus_obj(m_ConnectCancel);
       }
 
@@ -956,6 +978,7 @@ void UI::connectTimerHandler(lv_timer_t *timer) {
         // everything connected, display menu, hide connection message box
         lv_obj_add_flag(m_ConnectMessageBox, LV_OBJ_FLAG_HIDDEN);
         lv_obj_clear_flag(m_MainMenu.main, LV_OBJ_FLAG_HIDDEN);
+        UI::displayNavigationBar(true);
         lv_group_focus_next(lv_group_get_default());
       }
       break;

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -476,14 +476,17 @@ void UI::handleShutter(lv_event_t *e) {
     case LV_EVENT_PRESSED:
       if (ui->m_FocusPressed) {
         ui->shutterLock(control);
-      } else {
+      } else if (!ui->isShutterLocked()) {
         control.sendCommand(Control::CMD_SHUTTER_PRESS);
       }
       break;
     case LV_EVENT_RELEASED:
-      control.sendCommand(Control::CMD_SHUTTER_RELEASE);
-      if (!ui->m_FocusPressed) {
-        ui->shutterUnlock(control);
+      if (ui->isShutterLocked()) {
+        if (!ui->m_FocusPressed) {
+          ui->shutterUnlock(control);
+        }
+      } else {
+        control.sendCommand(Control::CMD_SHUTTER_RELEASE);
       }
       break;
     default:
@@ -497,9 +500,12 @@ void UI::handleFocus(lv_event_t *e) {
   lv_event_code_t code = lv_event_get_code(e);
   switch (code) {
     case LV_EVENT_PRESSED:
-      ui->shutterUnlock(control);
       ui->m_FocusPressed = true;
-      control.sendCommand(Control::CMD_FOCUS_PRESS);
+      if (ui->isShutterLocked()) {
+        ui->shutterUnlock(control);
+      } else {
+        control.sendCommand(Control::CMD_FOCUS_PRESS);
+      }
       break;
     case LV_EVENT_RELEASED:
       ui->m_FocusPressed = false;

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -1617,10 +1617,11 @@ void UI::addThemeMenu(const menu_t &parent) {
 void UI::addTransmitPowerMenu(const menu_t &parent) {
   menu_t &menu = addMenu(m_TransmitPowerStr, NULL, true, parent);
   lv_obj_t *cont = lv_menu_cont_create(menu.page);
-  lv_obj_set_height(cont, LV_PCT(100));
+  lv_obj_set_size(cont, LV_PCT(100), LV_PCT(100));
   lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
   lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
   lv_obj_t *slider = lv_slider_create(cont);
+  lv_obj_set_width(slider, LV_PCT(80));
   lv_slider_set_range(slider, 0, 2);
 
   uint8_t power = Settings::load<uint8_t>(Settings::TX_POWER);

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -830,6 +830,9 @@ void UI::addMainMenu(void) {
           if (M5.Touch.isEnabled()) {
             // if touch screen, enable back
             lv_obj_remove_state(back, LV_STATE_DISABLED);
+          } else {
+            // hide the back button
+            lv_obj_add_flag(back, LV_OBJ_FLAG_HIDDEN);
           }
         } else if (page == m_Menu.at(m_IntervalometerStr).page) {
           // always display 'Back' in intervalometer

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -1603,13 +1603,10 @@ void UI::addThemeMenu(const menu_t &parent) {
           auto *theme = static_cast<std::string *>(lv_event_get_user_data(e));
           setTheme(*theme);
           Settings::save<std::string>(Settings::THEME, *theme);
+          esp_restart();
         },
         LV_EVENT_CLICKED, (void *)&theme);
   }
-
-  // add restart button
-  lv_obj_t *restart = addMenuItem(menu, NULL, "Restart");
-  lv_obj_add_event_cb(restart, [](lv_event_t *e) { esp_restart(); }, LV_EVENT_CLICKED, NULL);
 
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -1603,8 +1603,8 @@ void UI::addBacklightMenu(const menu_t &parent) {
 
   lv_obj_t *roller = lv_roller_create(cont);
   lv_obj_set_width(roller, LV_PCT(90));
-  lv_roller_set_options(roller, "Never\n30 secs\n60 secs", LV_ROLLER_MODE_INFINITE);
-  lv_roller_set_visible_row_count(roller, 1);
+  lv_roller_set_options(roller, "Never\n30 secs\n60 secs", LV_ROLLER_MODE_NORMAL);
+  lv_roller_set_visible_row_count(roller, 2);
   uint8_t inactivity = Settings::load<uint8_t>(Settings::INACTIVITY);
   lv_roller_set_selected(roller, inactivity, LV_ANIM_ON);
 

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -823,8 +823,9 @@ void UI::addMainMenu(void) {
           // Ensure no active scans
           scan.stop();
 
-          // disable back button and shift focus
+          // hide and disable back button
           lv_obj_add_state(back, LV_STATE_DISABLED);
+          lv_obj_add_flag(back, LV_OBJ_FLAG_HIDDEN);
         } else if (page == m_Menu.at(m_RemoteShutter).page) {
           if (M5.Touch.isEnabled()) {
             // if touch screen, enable back


### PR DESCRIPTION
# M5StickC
* remove 'Back' in connect menu
* fix transmit power menu

# M5Stack Core2
* increase font size
   * attempt to make fat fingers less clumsy

# All
* change the outline colour of all buttons (including "Back" arrow '<')
   * an attempt to improve visual identification of what is under focus
* change backlight timeout selector to have more context
   * outline colour also changed to match buttons
