### PR TITLE
Add screen lock mechanism for touch screens (M5 Core2).

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ During shutter control:
 * press and hold 'Shutter Lock' to lock shutter open
    * press and hold 'Shutter Lock' again to release
 
+To activate screen lock:
+* double click the PWR button
+   * a message box will open
+* double click the PWR button to unlock
+
 ### Menu Map
 
 * Connect (if connections are saved)

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -63,6 +63,7 @@ class UI {
     lv_obj_t *batteryIcon;
     lv_obj_t *reconnectIcon;
     lv_obj_t *gpsData;
+    bool screenLocked;
   } status_t;
 
   class Intervalometer {


### PR DESCRIPTION
On PWR button double-click, lock or unlock the screen. This is implemented as a modal message box that just blocks all touch input.