### PR TITLE
Add support for v1.1 GPS unit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,17 @@ Connection to mobile devices is a little iffy:
 
 ### GPS Location Tagging
 
-> [!WARNING]
-> This unit is EOL, support for the replacement is pending (see #141).
-
 For Fujifilm cameras, location tagging is supported with the M5Stack GPS unit:
+- [GPS/BDS Unit v1.1 (AT6668)](https://shop.m5stack.com/products/gps-bds-unit-v1-1-at6668)
+
+The previous unit is now EOL:
 - [Mini GPS/BDS Unit](https://shop.m5stack.com/products/mini-gps-bds-unit)
 
 GPS support can be enabled in `furble` in `Settings->GPS`, the camera must also be configured to request location data.
+
+The default baud rate for the GPS unit is 9600.
+The new v1.1 unit runs at a higher baud rate and must be configured under
+`Settings->GPS->GPS baud 115200` for correct operation.
 
 ### Intervalometer
 

--- a/include/FurbleGPS.h
+++ b/include/FurbleGPS.h
@@ -1,6 +1,8 @@
 #ifndef FURBLE_GPS_H
 #define FURBLE_GPS_H
 
+#include <HardwareSerial.h>
+
 #include <lvgl.h>
 
 #include <TinyGPS++.h>
@@ -28,7 +30,8 @@ class GPS {
  private:
   GPS() {};
 
-  static constexpr const uint32_t BAUD = 9600;
+  static constexpr const size_t BUFFER_SIZE = 64;
+
 #if FURBLE_GROVE_CORE
   static constexpr const int8_t RX = 22;
   static constexpr const int8_t TX = 21;
@@ -36,10 +39,12 @@ class GPS {
   static constexpr const int8_t RX = 33;
   static constexpr const int8_t TX = 32;
 #endif
-  static constexpr const uint16_t SERVICE_MS = 250;
+  static constexpr const uint16_t SERVICE_MS = 25;
   static constexpr const uint32_t MAX_AGE_MS = 60 * 1000;
 
   void serviceSerial(void);
+
+  HardwareSerial m_SerialPort = HardwareSerial(2);
 
   lv_obj_t *m_Icon = NULL;
   lv_timer_t *m_Timer = NULL;

--- a/include/FurbleSettings.h
+++ b/include/FurbleSettings.h
@@ -19,6 +19,7 @@ class Settings {
     THEME,
     TX_POWER,
     GPS,
+    GPS_BAUD,
     INTERVAL,
     MULTICONNECT,
     RECONNECT,
@@ -31,6 +32,9 @@ class Settings {
     const char *key;
     const char *nvs_namespace;
   } setting_t;
+
+  static const uint32_t BAUD_9600 = 9600;
+  static const uint32_t BAUD_115200 = 115200;
 
   static void init(void);
 

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -62,6 +62,7 @@ class UI {
     lv_obj_t *gpsIcon;
     lv_obj_t *batteryIcon;
     lv_obj_t *reconnectIcon;
+    lv_obj_t *gpsBaud;
     lv_obj_t *gpsData;
     bool screenLocked;
   } status_t;

--- a/src/FurbleSettings.cpp
+++ b/src/FurbleSettings.cpp
@@ -7,12 +7,15 @@
 namespace Furble {
 Preferences Settings::m_Prefs;
 
+const uint32_t Settings::BAUD_9600;
+
 const std::unordered_map<Settings::type_t, Settings::setting_t> Settings::m_Setting = {
     {BRIGHTNESS,   {BRIGHTNESS, "Brightness", "brightness", "M5ez"}           },
     {INACTIVITY,   {INACTIVITY, "Inactivity", "inactivity", "M5ez"}           },
     {THEME,        {THEME, "Theme", "theme", "M5ez"}                          },
     {TX_POWER,     {TX_POWER, "TX Power", "tx_power", FURBLE_STR}             },
     {GPS,          {GPS, "GPS", "gps", FURBLE_STR}                            },
+    {GPS_BAUD,     {GPS_BAUD, "GPS Baud", "gps_baud", FURBLE_STR}             },
     {INTERVAL,     {INTERVAL, "Interval", "interval", FURBLE_STR}             },
     {MULTICONNECT, {MULTICONNECT, "Multi-Connect", "multiconnect", FURBLE_STR}},
     {RECONNECT,    {RECONNECT, "Infinite-ReConnect", "reconnect", FURBLE_STR} },
@@ -38,6 +41,16 @@ uint8_t Settings::load<uint8_t>(type_t type) {
   const auto &setting = get(type);
   m_Prefs.begin(setting.nvs_namespace, true);
   uint8_t value = m_Prefs.getUChar(setting.key);
+  m_Prefs.end();
+
+  return value;
+}
+
+template <>
+uint32_t Settings::load<uint32_t>(type_t type) {
+  const auto &setting = get(type);
+  m_Prefs.begin(setting.nvs_namespace, true);
+  uint32_t value = m_Prefs.getUInt(setting.key);
   m_Prefs.end();
 
   return value;
@@ -107,6 +120,14 @@ void Settings::save<uint8_t>(const type_t type, const uint8_t &value) {
 }
 
 template <>
+void Settings::save<uint32_t>(const type_t type, const uint32_t &value) {
+  const auto &setting = get(type);
+  m_Prefs.begin(setting.nvs_namespace, false);
+  m_Prefs.putUInt(setting.key, value);
+  m_Prefs.end();
+}
+
+template <>
 void Settings::save<interval_t>(const type_t type, const interval_t &value) {
   const auto &setting = get(type);
   m_Prefs.begin(setting.nvs_namespace, false);
@@ -154,6 +175,9 @@ void Settings::init(void) {
         case RECONNECT:
         case FAUXNY:
           save<bool>(setting.type, false);
+          break;
+        case GPS_BAUD:
+          save<uint32_t>(setting.type, BAUD_9600);
           break;
       }
     }


### PR DESCRIPTION
Add a setting for the GPS unit baud rate, defaults to 9600 (the old EOL) unit.
The new (v1.1) unit runs at 115200.

Also, add the GPS time age to the 'GPS Data' output. Update the GPS service interval to 50ms, to support the faster unit (may need to convert this to a FreeRTOS task/queue).

Whilst here, refactor a bit of GPS handling.