### PR TITLE
Namespace refactor and NimBLEUUID cleanup.

### DIFF
--- a/lib/furble/CanonEOS.h
+++ b/lib/furble/CanonEOS.h
@@ -1,6 +1,8 @@
 #ifndef CANONEOS_H
 #define CANONEOS_H
 
+#include <NimBLEUUID.h>
+
 #include "Camera.h"
 #include "Device.h"
 
@@ -21,35 +23,35 @@ class CanonEOS: public Camera {
   CanonEOS(Type type, const void *data, size_t len);
   CanonEOS(Type type, const NimBLEAdvertisedDevice *pDevice);
 
-  const char *CANON_EOS_SVC_IDEN_UUID = "00010000-0000-1000-0000-d8492fffa821";
+  const NimBLEUUID SVC_IDEN_UUID {0x00010000, 0x0000, 0x1000, 0x0000d8492fffa821};
   /** 0xf108 */
-  const char *CANON_EOS_CHR_NAME_UUID = "00010006-0000-1000-0000-d8492fffa821";
+  const NimBLEUUID CHR_NAME_UUID {0x00010006, 0x0000, 0x1000, 0x0000d8492fffa821};
   /** 0xf104 */
-  const char *CANON_EOS_CHR_IDEN_UUID = "0001000a-0000-1000-0000-d8492fffa821";
+  const NimBLEUUID CHR_IDEN_UUID {0x0001000a, 0x0000, 0x1000, 0x0000d8492fffa821};
 
-  const char *CANON_EOS_SVC_MODE_UUID = "00030000-0000-1000-0000-d8492fffa821";
+  const NimBLEUUID SVC_MODE_UUID {0x00030000, 0x0000, 0x1000, 0x0000d8492fffa821};
   /** 0xf307 */
-  const char *CANON_EOS_CHR_MODE_UUID = "00030010-0000-1000-0000-d8492fffa821";
+  const NimBLEUUID CHR_MODE_UUID {0x00030010, 0x0000, 0x1000, 0x0000d8492fffa821};
 
-  const char *CANON_EOS_SVC_SHUTTER_UUID = "00030000-0000-1000-0000-d8492fffa821";
+  const NimBLEUUID SVC_SHUTTER_UUID {0x00030000, 0x0000, 0x1000, 0x0000d8492fffa821};
   /** 0xf311 */
-  const char *CANON_EOS_CHR_SHUTTER_UUID = "00030030-0000-1000-0000-d8492fffa821";
+  const NimBLEUUID CHR_SHUTTER_UUID {0x00030030, 0x0000, 0x1000, 0x0000d8492fffa821};
 
-  const uint8_t CANON_EOS_PAIR_ACCEPT = 0x02;
-  const uint8_t CANON_EOS_PAIR_REJECT = 0x03;
-  uint8_t CANON_EOS_MODE_PLAYBACK = 0x01;
-  uint8_t CANON_EOS_MODE_SHOOT = 0x02;
-  uint8_t CANON_EOS_MODE_WAKE = 0x03;
+  static constexpr uint8_t PAIR_ACCEPT = 0x02;
+  static constexpr uint8_t PAIR_REJECT = 0x03;
+  static constexpr uint8_t MODE_PLAYBACK = 0x01;
+  static constexpr uint8_t MODE_SHOOT = 0x02;
+  static constexpr uint8_t MODE_WAKE = 0x03;
 
   bool write_value(NimBLEClient *pClient,
-                   const char *serviceUUID,
-                   const char *characteristicUUID,
+                   const NimBLEUUID &serviceUUID,
+                   const NimBLEUUID &characteristicUUID,
                    const uint8_t *data,
                    size_t length);
 
   bool write_prefix(NimBLEClient *pClient,
-                    const char *serviceUUID,
-                    const char *characteristicUUID,
+                    const NimBLEUUID &serviceUUID,
+                    const NimBLEUUID &characteristicUUID,
                     const uint8_t prefix,
                     const uint8_t *data,
                     size_t length);

--- a/lib/furble/FauxNY.h
+++ b/lib/furble/FauxNY.h
@@ -28,7 +28,7 @@ class FauxNY: public Camera {
   void _disconnect(void) override;
 
  private:
-  typedef struct _eos_t {
+  typedef struct _fauxNY_t {
     char name[MAX_NAME]; /** Human readable device name. */
     uint64_t address;    /** Device MAC address. */
     uint8_t type;        /** Address type. */

--- a/lib/furble/Fujifilm.cpp
+++ b/lib/furble/Fujifilm.cpp
@@ -7,56 +7,14 @@
 #include "Device.h"
 #include "Fujifilm.h"
 
-typedef struct _fujifilm_t {
-  char name[MAX_NAME];               /** Human readable device name. */
-  uint64_t address;                  /** Device MAC address. */
-  uint8_t type;                      /** Address type. */
-  uint8_t token[FUJIFILM_TOKEN_LEN]; /** Pairing token. */
-} fujifilm_t;
-
-// 0x4001
-static const NimBLEUUID FUJIFILM_SVC_PAIR_UUID = NimBLEUUID("91f1de68-dff6-466e-8b65-ff13b0f16fb8");
-// 0x4042
-static const NimBLEUUID FUJIFILM_CHR_PAIR_UUID = NimBLEUUID("aba356eb-9633-4e60-b73f-f52516dbd671");
-// 0x4012
-static const NimBLEUUID FUJIFILM_CHR_IDEN_UUID = NimBLEUUID("85b9163e-62d1-49ff-a6f5-054b4630d4a1");
-
-// Currently unused
-// static const char *FUJIFILM_SVC_READ_UUID =
-// "4e941240-d01d-46b9-a5ea-67636806830b"; static const char
-// *FUJIFILM_CHR_READ_UUID = "bf6dc9cf-3606-4ec9-a4c8-d77576e93ea4";
-
-static const NimBLEUUID FUJIFILM_SVC_CONF_UUID = NimBLEUUID("4c0020fe-f3b6-40de-acc9-77d129067b14");
-// 0x5013
-static const NimBLEUUID FUJIFILM_CHR_IND1_UUID = NimBLEUUID("a68e3f66-0fcc-4395-8d4c-aa980b5877fa");
-// 0x5023
-static const NimBLEUUID FUJIFILM_CHR_IND2_UUID = NimBLEUUID("bd17ba04-b76b-4892-a545-b73ba1f74dae");
-// 0x5033
-static const NimBLEUUID FUJIFILM_CHR_NOT1_UUID = NimBLEUUID("f9150137-5d40-4801-a8dc-f7fc5b01da50");
-// 0x5043
-static const NimBLEUUID FUJIFILM_CHR_NOT2_UUID = NimBLEUUID("ad06c7b7-f41a-46f4-a29a-712055319122");
-static const NimBLEUUID FUJIFILM_CHR_IND3_UUID = NimBLEUUID("049ec406-ef75-4205-a390-08fe209c51f0");
-
-static const NimBLEUUID FUJIFILM_SVC_SHUTTER_UUID =
-    NimBLEUUID("6514eb81-4e8f-458d-aa2a-e691336cdfac");
-static const NimBLEUUID FUJIFILM_CHR_SHUTTER_UUID =
-    NimBLEUUID("7fcf49c6-4ff0-4777-a03d-1a79166af7a8");
-
-static const NimBLEUUID FUJIFILM_SVC_GEOTAG_UUID =
-    NimBLEUUID("3b46ec2b-48ba-41fd-b1b8-ed860b60d22b");
-static const NimBLEUUID FUJIFILM_CHR_GEOTAG_UUID =
-    NimBLEUUID("0f36ec14-29e5-411a-a1b6-64ee8383f090");
-
-static const NimBLEUUID FUJIFILM_GEOTAG_UPDATE = NimBLEUUID("ad06c7b7-f41a-46f4-a29a-712055319122");
-
-static constexpr std::array<uint8_t, 2> FUJIFILM_SHUTTER_RELEASE = {0x00, 0x00};
-static constexpr std::array<uint8_t, 2> FUJIFILM_SHUTTER_CMD = {0x01, 0x00};
-static constexpr std::array<uint8_t, 2> FUJIFILM_SHUTTER_PRESS = {0x02, 0x00};
-static constexpr std::array<uint8_t, 2> FUJIFILM_SHUTTER_FOCUS = {0x03, 0x00};
-
 namespace Furble {
 
-static void print_token(const std::array<uint8_t, FUJIFILM_TOKEN_LEN> &token) {
+constexpr std::array<uint8_t, 2> Fujifilm::SHUTTER_RELEASE;
+constexpr std::array<uint8_t, 2> Fujifilm::SHUTTER_CMD;
+constexpr std::array<uint8_t, 2> Fujifilm::SHUTTER_PRESS;
+constexpr std::array<uint8_t, 2> Fujifilm::SHUTTER_FOCUS;
+
+void Fujifilm::print_token(const std::array<uint8_t, TOKEN_LEN> &token) {
   ESP_LOGI(LOG_TAG, "Token = %02x%02x%02x%02x", token[0], token[1], token[2], token[3]);
 }
 
@@ -69,11 +27,11 @@ void Fujifilm::notify(BLERemoteCharacteristic *pChr, uint8_t *pData, size_t leng
     }
   }
 
-  if (pChr->getUUID() == FUJIFILM_CHR_NOT1_UUID) {
+  if (pChr->getUUID() == CHR_NOT1_UUID) {
     if ((length >= 2) && (pData[0] == 0x02) && (pData[1] == 0x00)) {
       m_Configured = true;
     }
-  } else if (pChr->getUUID() == FUJIFILM_GEOTAG_UPDATE) {
+  } else if (pChr->getUUID() == GEOTAG_UPDATE) {
     if ((length >= 2) && (pData[0] == 0x01) && (pData[1] == 0x00)) {
       m_GeoRequested = true;
     }
@@ -108,7 +66,7 @@ Fujifilm::Fujifilm(const void *data, size_t len) : Camera(Type::FUJIFILM) {
   const fujifilm_t *fujifilm = static_cast<const fujifilm_t *>(data);
   m_Name = std::string(fujifilm->name);
   m_Address = NimBLEAddress(fujifilm->address, fujifilm->type);
-  memcpy(m_Token.data(), fujifilm->token, FUJIFILM_TOKEN_LEN);
+  memcpy(m_Token.data(), fujifilm->token, TOKEN_LEN);
 }
 
 Fujifilm::Fujifilm(const NimBLEAdvertisedDevice *pDevice) : Camera(Type::FUJIFILM) {
@@ -121,19 +79,13 @@ Fujifilm::Fujifilm(const NimBLEAdvertisedDevice *pDevice) : Camera(Type::FUJIFIL
   print_token(m_Token);
 }
 
-constexpr size_t FUJIFILM_ADV_TOKEN_LEN = 7;
-constexpr uint8_t FUJIFILM_ID_0 = 0xd8;
-constexpr uint8_t FUJIFILM_ID_1 = 0x04;
-constexpr uint8_t FUJIFILM_TYPE_TOKEN = 0x02;
-
 /**
  * Determine if the advertised BLE device is a Fujifilm.
  */
 bool Fujifilm::matches(const NimBLEAdvertisedDevice *pDevice) {
-  if (pDevice->haveManufacturerData()
-      && pDevice->getManufacturerData().length() == FUJIFILM_ADV_TOKEN_LEN) {
+  if (pDevice->haveManufacturerData() && pDevice->getManufacturerData().length() == ADV_TOKEN_LEN) {
     const char *data = pDevice->getManufacturerData().data();
-    if (data[0] == FUJIFILM_ID_0 && data[1] == FUJIFILM_ID_1 && data[2] == FUJIFILM_TYPE_TOKEN) {
+    if (data[0] == ID_0 && data[1] == ID_1 && data[2] == TYPE_TOKEN) {
       return true;
     }
   }
@@ -159,12 +111,12 @@ bool Fujifilm::_connect(void) {
 
   ESP_LOGI(LOG_TAG, "Connected");
   m_Progress = 20;
-  pSvc = m_Client->getService(FUJIFILM_SVC_PAIR_UUID);
+  pSvc = m_Client->getService(SVC_PAIR_UUID);
   if (pSvc == nullptr)
     return false;
 
   ESP_LOGI(LOG_TAG, "Pairing");
-  pChr = pSvc->getCharacteristic(FUJIFILM_CHR_PAIR_UUID);
+  pChr = pSvc->getCharacteristic(CHR_PAIR_UUID);
   if (pChr == nullptr)
     return false;
 
@@ -177,7 +129,7 @@ bool Fujifilm::_connect(void) {
   m_Progress = 30;
 
   ESP_LOGI(LOG_TAG, "Identifying");
-  pChr = pSvc->getCharacteristic(FUJIFILM_CHR_IDEN_UUID);
+  pChr = pSvc->getCharacteristic(CHR_IDEN_UUID);
   if (!pChr->canWrite())
     return false;
   const auto name = Device::getStringID();
@@ -188,11 +140,11 @@ bool Fujifilm::_connect(void) {
 
   // indications
   ESP_LOGI(LOG_TAG, "Configuring");
-  if (!this->subscribe(FUJIFILM_SVC_CONF_UUID, FUJIFILM_CHR_IND1_UUID, false)) {
+  if (!this->subscribe(SVC_CONF_UUID, CHR_IND1_UUID, false)) {
     return false;
   }
 
-  if (!this->subscribe(FUJIFILM_SVC_CONF_UUID, FUJIFILM_CHR_IND2_UUID, false)) {
+  if (!this->subscribe(SVC_CONF_UUID, CHR_IND2_UUID, false)) {
     return false;
   }
   m_Progress = 50;
@@ -208,17 +160,17 @@ bool Fujifilm::_connect(void) {
 
   m_Progress = 60;
   // notifications
-  if (!this->subscribe(FUJIFILM_SVC_CONF_UUID, FUJIFILM_CHR_NOT1_UUID, true)) {
+  if (!this->subscribe(SVC_CONF_UUID, CHR_NOT1_UUID, true)) {
     return false;
   }
   m_Progress = 70;
 
-  if (!this->subscribe(FUJIFILM_SVC_CONF_UUID, FUJIFILM_CHR_NOT2_UUID, true)) {
+  if (!this->subscribe(SVC_CONF_UUID, CHR_NOT2_UUID, true)) {
     return false;
   }
   m_Progress = 80;
 
-  if (!this->subscribe(FUJIFILM_SVC_CONF_UUID, FUJIFILM_CHR_IND3_UUID, false)) {
+  if (!this->subscribe(SVC_CONF_UUID, CHR_IND3_UUID, false)) {
     return false;
   }
   m_Progress = 100;
@@ -232,9 +184,9 @@ bool Fujifilm::_connect(void) {
 template <std::size_t N>
 void Fujifilm::sendShutterCommand(const std::array<uint8_t, N> &cmd,
                                   const std::array<uint8_t, N> &param) {
-  NimBLERemoteService *pSvc = m_Client->getService(FUJIFILM_SVC_SHUTTER_UUID);
+  NimBLERemoteService *pSvc = m_Client->getService(SVC_SHUTTER_UUID);
   if (pSvc) {
-    NimBLERemoteCharacteristic *pChr = pSvc->getCharacteristic(FUJIFILM_CHR_SHUTTER_UUID);
+    NimBLERemoteCharacteristic *pChr = pSvc->getCharacteristic(CHR_SHUTTER_UUID);
     if ((pChr != nullptr) && pChr->canWrite()) {
       pChr->writeValue(cmd.data(), sizeof(cmd), true);
       pChr->writeValue(param.data(), sizeof(cmd), true);
@@ -243,15 +195,15 @@ void Fujifilm::sendShutterCommand(const std::array<uint8_t, N> &cmd,
 }
 
 void Fujifilm::shutterPress(void) {
-  sendShutterCommand(FUJIFILM_SHUTTER_CMD, FUJIFILM_SHUTTER_PRESS);
+  sendShutterCommand(SHUTTER_CMD, SHUTTER_PRESS);
 }
 
 void Fujifilm::shutterRelease(void) {
-  sendShutterCommand(FUJIFILM_SHUTTER_CMD, FUJIFILM_SHUTTER_RELEASE);
+  sendShutterCommand(SHUTTER_CMD, SHUTTER_RELEASE);
 }
 
 void Fujifilm::focusPress(void) {
-  sendShutterCommand(FUJIFILM_SHUTTER_CMD, FUJIFILM_SHUTTER_FOCUS);
+  sendShutterCommand(SHUTTER_CMD, SHUTTER_FOCUS);
 }
 
 void Fujifilm::focusRelease(void) {
@@ -259,12 +211,12 @@ void Fujifilm::focusRelease(void) {
 }
 
 void Fujifilm::sendGeoData(const gps_t &gps, const timesync_t &timesync) {
-  NimBLERemoteService *pSvc = m_Client->getService(FUJIFILM_SVC_GEOTAG_UUID);
+  NimBLERemoteService *pSvc = m_Client->getService(SVC_GEOTAG_UUID);
   if (pSvc == nullptr) {
     return;
   }
 
-  NimBLERemoteCharacteristic *pChr = pSvc->getCharacteristic(FUJIFILM_CHR_GEOTAG_UUID);
+  NimBLERemoteCharacteristic *pChr = pSvc->getCharacteristic(CHR_GEOTAG_UUID);
   if (pChr == nullptr) {
     return;
   }
@@ -327,7 +279,7 @@ bool Fujifilm::serialise(void *buffer, size_t bytes) const {
   strncpy(x->name, m_Name.c_str(), MAX_NAME);
   x->address = (uint64_t)m_Address;
   x->type = m_Address.getType();
-  memcpy(x->token, m_Token.data(), FUJIFILM_TOKEN_LEN);
+  memcpy(x->token, m_Token.data(), TOKEN_LEN);
 
   return true;
 }

--- a/lib/furble/Fujifilm.h
+++ b/lib/furble/Fujifilm.h
@@ -5,8 +5,6 @@
 
 #include "Camera.h"
 
-#define FUJIFILM_TOKEN_LEN (4)
-
 namespace Furble {
 /**
  * Fujifilm X.
@@ -34,6 +32,12 @@ class Fujifilm: public Camera {
   void _disconnect(void) override;
 
  private:
+  static constexpr size_t TOKEN_LEN = 4;
+  static constexpr size_t ADV_TOKEN_LEN = 7;
+  static constexpr uint8_t ID_0 = 0xd8;
+  static constexpr uint8_t ID_1 = 0x04;
+  static constexpr uint8_t TYPE_TOKEN = 0x02;
+
   /**
    * Time synchronisation.
    */
@@ -57,6 +61,52 @@ class Fujifilm: public Camera {
     fujifilm_time_t gps_time;
   } geotag_t;
 
+  /**
+   * Non-volatile storage type.
+   */
+  typedef struct _fujifilm_t {
+    char name[MAX_NAME];      /** Human readable device name. */
+    uint64_t address;         /** Device MAC address. */
+    uint8_t type;             /** Address type. */
+    uint8_t token[TOKEN_LEN]; /** Pairing token. */
+  } fujifilm_t;
+
+  // 0x4001
+  const NimBLEUUID SVC_PAIR_UUID {0x91f1de68, 0xdff6, 0x466e, 0x8b65ff13b0f16fb8};
+  // 0x4042
+  const NimBLEUUID CHR_PAIR_UUID {0xaba356eb, 0x9633, 0x4e60, 0xb73ff52516dbd671};
+  // 0x4012
+  const NimBLEUUID CHR_IDEN_UUID {0x85b9163e, 0x62d1, 0x49ff, 0xa6f5054b4630d4a1};
+
+  // Currently unused
+  // const NimBLEUUID SVC_READ_UUID{0x4e941240, 0xd01d, 0x46b9, 0xa5ea67636806830b};
+  // const NimBLEUUID CHR_READ_UUID{0xbf6dc9cf, 0x3606, 0x4ec9, 0xa4c8d77576e93ea4};
+
+  const NimBLEUUID SVC_CONF_UUID {0x4c0020fe, 0xf3b6, 0x40de, 0xacc977d129067b14};
+  // 0x5013
+  const NimBLEUUID CHR_IND1_UUID {0xa68e3f66, 0x0fcc, 0x4395, 0x8d4caa980b5877fa};
+  // 0x5023
+  const NimBLEUUID CHR_IND2_UUID {0xbd17ba04, 0xb76b, 0x4892, 0xa545b73ba1f74dae};
+  // 0x5033
+  const NimBLEUUID CHR_NOT1_UUID {0xf9150137, 0x5d40, 0x4801, 0xa8dcf7fc5b01da50};
+  // 0x5043
+  const NimBLEUUID CHR_NOT2_UUID {0xad06c7b7, 0xf41a, 0x46f4, 0xa29a712055319122};
+  const NimBLEUUID CHR_IND3_UUID {0x049ec406, 0xef75, 0x4205, 0xa39008fe209c51f0};
+
+  const NimBLEUUID SVC_SHUTTER_UUID {0x6514eb81, 0x4e8f, 0x458d, 0xaa2ae691336cdfac};
+  const NimBLEUUID CHR_SHUTTER_UUID {0x7fcf49c6, 0x4ff0, 0x4777, 0xa03d1a79166af7a8};
+
+  const NimBLEUUID SVC_GEOTAG_UUID {0x3b46ec2b, 0x48ba, 0x41fd, 0xb1b8ed860b60d22b};
+  const NimBLEUUID CHR_GEOTAG_UUID {0x0f36ec14, 0x29e5, 0x411a, 0xa1b664ee8383f090};
+
+  const NimBLEUUID GEOTAG_UPDATE {0xad06c7b7, 0xf41a, 0x46f4, 0xa29a712055319122};
+
+  static constexpr std::array<uint8_t, 2> SHUTTER_RELEASE = {0x00, 0x00};
+  static constexpr std::array<uint8_t, 2> SHUTTER_CMD = {0x01, 0x00};
+  static constexpr std::array<uint8_t, 2> SHUTTER_PRESS = {0x02, 0x00};
+  static constexpr std::array<uint8_t, 2> SHUTTER_FOCUS = {0x03, 0x00};
+
+  void print_token(const std::array<uint8_t, TOKEN_LEN> &token);
   void print(void);
   void notify(NimBLERemoteCharacteristic *, uint8_t *, size_t, bool);
   bool subscribe(const NimBLEUUID &svc, const NimBLEUUID &chr, bool notifications);
@@ -65,7 +115,7 @@ class Fujifilm: public Camera {
   template <std::size_t N>
   void sendShutterCommand(const std::array<uint8_t, N> &cmd, const std::array<uint8_t, N> &param);
 
-  std::array<uint8_t, FUJIFILM_TOKEN_LEN> m_Token = {0};
+  std::array<uint8_t, TOKEN_LEN> m_Token = {0};
 
   bool m_Configured = false;
 


### PR DESCRIPTION
Move most of the UUIDs into the per-camera namespace and reduce the identifier names.

Change to the hex-parts NimBLEUUID constructor, no need to parse strings here.