### PR TITLE
Initialise NVS.

### DIFF
--- a/src/FurbleGPS.cpp
+++ b/src/FurbleGPS.cpp
@@ -80,7 +80,6 @@ void GPS::serviceSerial(void) {
   size_t available = m_SerialPort.available();
   if (available > 0) {
     size_t bytes = m_SerialPort.readBytes(buffer.data(), std::min(buffer.size(), available));
-    ESP_LOGI("gps", "bytes = %u", bytes);
 
     for (size_t i = 0; i < bytes; i++) {
       m_GPS.encode(buffer[i]);

--- a/src/FurbleSettings.cpp
+++ b/src/FurbleSettings.cpp
@@ -1,4 +1,5 @@
 #include <esp_bt.h>
+#include <nvs_flash.h>
 
 #include "FurbleTypes.h"
 
@@ -144,6 +145,14 @@ void Settings::save<std::string>(const type_t type, const std::string &value) {
 }
 
 void Settings::init(void) {
+  // Initialize NVS
+  esp_err_t ret = nvs_flash_init();
+  if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+    ESP_ERROR_CHECK(nvs_flash_erase());
+    ret = nvs_flash_init();
+  }
+  ESP_ERROR_CHECK(ret);
+
   // Set default values for all settings
   for (const auto &it : m_Setting) {
     auto &setting = it.second;


### PR DESCRIPTION
Migration to IDF means we need to manually initialize the NVS ourselves. Otherwise, we can't save anything ...