### PR TITLE
Adjust UI for devices with physical buttons

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,3 +6,6 @@ BreakBeforeBinaryOperators: NonAssignment
 SpaceBeforeInheritanceColon: false
 AlignArrayOfStructures: Left
 SpaceBeforeCpp11BracedList: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: true

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -35,6 +35,9 @@ class UI {
   /** Configure menu control. */
   void configMenuControl(void);
 
+  /** Configure slider control. */
+  void configSliderControl(void);
+
   /** Display shutter intervalometer menu .*/
   void showShutterIntervalometer(bool show);
 

--- a/include/lv_conf.h
+++ b/include/lv_conf.h
@@ -67,9 +67,9 @@
  *(Not so important, you can adjust it to modify default sizes and spaces)*/
 #if defined(FURBLE_M5STICKC)
 #define LV_DPI_DEF (64)
-#elif defined(FURBLE_M5STICKC_PLUS)
-#define LV_DPI_DEF (128)
-#elif defined(FURBLE_M5COREX)
+#elif defined(FURBLE_M5STACK_CORE)
+#define LV_DPI_DEF (96)
+#elif defined(FURBLE_M5STICKC_PLUS) || defined(FURBLE_M5COREX)
 #define LV_DPI_DEF (128)
 #else
 #error "furble: Unknown platform"

--- a/src/FurbleSettings.cpp
+++ b/src/FurbleSettings.cpp
@@ -171,7 +171,8 @@ void Settings::init(void) {
         case TX_POWER:
           save<uint8_t>(setting.type, 0);
           break;
-        case INTERVAL: {
+        case INTERVAL:
+        {
           interval_t interval = {
               INTERVAL_DEFAULT_COUNT,
               INTERVAL_DEFAULT_DELAY,

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -256,11 +256,11 @@ UI::UI(const interval_t &interval) : m_GPS {GPS::getInstance()}, m_Intervalomete
         m_Right = lv_button_create(m_Screen);
 
         lv_obj_add_flag(m_Left, LV_OBJ_FLAG_FLOATING);
-        lv_obj_align(m_Left, LV_ALIGN_BOTTOM_LEFT, 0, 0);
+        lv_obj_align(m_Left, LV_ALIGN_BOTTOM_LEFT, 0, -1);
 
         lv_obj_set_style_bg_image_src(m_Right, LV_SYMBOL_RIGHT, 0);
         lv_obj_add_flag(m_Right, LV_OBJ_FLAG_FLOATING);
-        lv_obj_align(m_Right, LV_ALIGN_BOTTOM_RIGHT, 0, 0);
+        lv_obj_align(m_Right, LV_ALIGN_RIGHT_MID, 0, 0);
         break;
 
       default:
@@ -270,6 +270,13 @@ UI::UI(const interval_t &interval) : m_GPS {GPS::getInstance()}, m_Intervalomete
         lv_obj_set_style_bg_image_src(m_Right, LV_SYMBOL_RIGHT, 0);
         break;
     }
+
+    // lighten the buttons 50%, to distinguish from other widget selection
+    lv_color_t lighter = lv_color_lighten(lv_obj_get_style_bg_color(m_Left, LV_PART_MAIN), 255/2);
+
+    lv_obj_set_style_bg_color(m_Left, lighter, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(m_OK, lighter, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(m_Right, lighter, LV_PART_MAIN);
 
     // prepare shutter handling
     prepareShutterControl();

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -258,7 +258,6 @@ UI::UI(const interval_t &interval) : m_GPS {GPS::getInstance()}, m_Intervalomete
         lv_obj_add_flag(m_Left, LV_OBJ_FLAG_FLOATING);
         lv_obj_align(m_Left, LV_ALIGN_BOTTOM_LEFT, 0, -1);
 
-        lv_obj_set_style_bg_image_src(m_Right, LV_SYMBOL_RIGHT, 0);
         lv_obj_add_flag(m_Right, LV_OBJ_FLAG_FLOATING);
         lv_obj_align(m_Right, LV_ALIGN_RIGHT_MID, 0, 0);
         break;
@@ -267,7 +266,6 @@ UI::UI(const interval_t &interval) : m_GPS {GPS::getInstance()}, m_Intervalomete
         m_Left = lv_button_create(m_NavBar);
         m_OK = lv_button_create(m_NavBar);
         m_Right = lv_button_create(m_NavBar);
-        lv_obj_set_style_bg_image_src(m_Right, LV_SYMBOL_RIGHT, 0);
         break;
     }
 
@@ -286,12 +284,12 @@ UI::UI(const interval_t &interval) : m_GPS {GPS::getInstance()}, m_Intervalomete
     lv_group_remove_obj(m_OK);
     lv_group_remove_obj(m_Right);
 
-    lv_obj_set_style_bg_image_src(m_Left, LV_SYMBOL_LEFT, 0);
     lv_obj_set_size(m_Left, height, height);
-    lv_obj_set_style_bg_image_src(m_OK, LV_SYMBOL_OK, 0);
     lv_obj_set_size(m_OK, height, height);
     lv_obj_set_size(m_Right, height, height);
   }
+
+  configMenuControl();
 
   // create connection timer
   m_ConnectTimer = lv_timer_create(connectTimerHandler, 125, NULL);
@@ -961,13 +959,21 @@ void UI::configShutterControl(void) {
 
 void UI::configMenuControl(void) {
   if (!M5.Touch.isEnabled()) {
-    lv_obj_set_style_bg_image_src(m_Left, LV_SYMBOL_LEFT, 0);
+    lv_obj_set_style_bg_image_src(m_Left, LV_SYMBOL_UP, 0);
     lv_obj_set_style_bg_image_src(m_OK, LV_SYMBOL_OK, 0);
-    lv_obj_set_style_bg_image_src(m_Right, LV_SYMBOL_RIGHT, 0);
+    lv_obj_set_style_bg_image_src(m_Right, LV_SYMBOL_DOWN, 0);
 
     lv_indev_set_type(m_ButtonL, LV_INDEV_TYPE_ENCODER);
     lv_indev_set_type(m_ButtonO, LV_INDEV_TYPE_ENCODER);
     lv_indev_set_type(m_ButtonR, LV_INDEV_TYPE_ENCODER);
+  }
+}
+
+void UI::configSliderControl(void) {
+  if (!M5.Touch.isEnabled()) {
+    lv_obj_set_style_bg_image_src(m_Left, LV_SYMBOL_LEFT, 0);
+    lv_obj_set_style_bg_image_src(m_OK, LV_SYMBOL_OK, 0);
+    lv_obj_set_style_bg_image_src(m_Right, LV_SYMBOL_RIGHT, 0);
   }
 }
 
@@ -1667,11 +1673,29 @@ void UI::addBacklightMenu(const menu_t &parent) {
   lv_obj_add_event_cb(
       slider,
       [](lv_event_t *e) {
+        auto *ui = static_cast<UI *>(lv_event_get_user_data(e));
         auto *slider = static_cast<lv_obj_t *>(lv_event_get_target(e));
-        auto brightness = lv_slider_get_value(slider) * m_BrightnessSteps;
-        M5.Display.setBrightness(brightness);
+        lv_event_code_t code = lv_event_get_code(e);
+
+        switch (code) {
+          case LV_EVENT_VALUE_CHANGED:
+          {
+            auto brightness = lv_slider_get_value(slider) * m_BrightnessSteps;
+            M5.Display.setBrightness(brightness);
+            break;
+          }
+          case LV_EVENT_FOCUSED:
+            if (lv_obj_has_state(slider, LV_STATE_EDITED)) {
+              ui->configSliderControl();
+            } else {
+              ui->configMenuControl();
+            }
+            break;
+          default:
+            break;
+        }
       },
-      LV_EVENT_VALUE_CHANGED, NULL);
+      LV_EVENT_ALL, this);
 
   lv_obj_add_event_cb(
       slider,
@@ -1770,13 +1794,31 @@ void UI::addTransmitPowerMenu(const menu_t &parent) {
   lv_obj_add_event_cb(
       slider,
       [](lv_event_t *e) {
+        auto *ui = static_cast<UI *>(lv_event_get_user_data(e));
         auto *slider = static_cast<lv_obj_t *>(lv_event_get_target(e));
-        auto power = lv_slider_get_value(slider);
-        auto &control = Control::getInstance();
-        Settings::save<uint8_t>(Settings::TX_POWER, power);
-        control.setPower(Settings::load<esp_power_level_t>(Settings::TX_POWER));
+        lv_event_code_t code = lv_event_get_code(e);
+
+        switch (code) {
+          case LV_EVENT_RELEASED:
+          {
+            auto power = lv_slider_get_value(slider);
+            auto &control = Control::getInstance();
+            Settings::save<uint8_t>(Settings::TX_POWER, power);
+            control.setPower(Settings::load<esp_power_level_t>(Settings::TX_POWER));
+            break;
+          }
+          case LV_EVENT_FOCUSED:
+            if (lv_obj_has_state(slider, LV_STATE_EDITED)) {
+              ui->configSliderControl();
+            } else {
+              ui->configMenuControl();
+            }
+            break;
+          default:
+            break;
+        }
       },
-      LV_EVENT_RELEASED, NULL);
+      LV_EVENT_ALL, this);
 
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -272,7 +272,7 @@ UI::UI(const interval_t &interval) : m_GPS {GPS::getInstance()}, m_Intervalomete
     }
 
     // lighten the buttons 50%, to distinguish from other widget selection
-    lv_color_t lighter = lv_color_lighten(lv_obj_get_style_bg_color(m_Left, LV_PART_MAIN), 255/2);
+    lv_color_t lighter = lv_color_lighten(lv_obj_get_style_bg_color(m_Left, LV_PART_MAIN), 255 / 2);
 
     lv_obj_set_style_bg_color(m_Left, lighter, LV_PART_MAIN);
     lv_obj_set_style_bg_color(m_OK, lighter, LV_PART_MAIN);


### PR DESCRIPTION
For M5StickC:
* move right button to match physical button location
* move the 'Back' button up by a pixel, it was ever so slightly off

For M5Stack Core:
* change the DPI for M5Stack Core so the main menu doesn't need scrolling

Lighten the navigation button colour by 50% to distinguish from menu selection (otherwise it's just a solid blob of colour on overlap).