### PR TITLE
Support for Sony ZV-1F.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 ![PlatformIO CI](https://github.com/gkoh/furble/workflows/PlatformIO%20CI/badge.svg)
 
 A Bluetooth wireless remote shutter release originally targeted at Fujifilm mirrorless
-cameras.
+cameras. furble now supports:
+- Fujifilm
+- Canon
+- Nikon
+- Sony
 
 The remote uses the camera's native Bluetooth Low Energy interface thus additional
 adapters are not required.
@@ -42,6 +46,8 @@ The following devices have been tested and confirmed to work:
    - Canon EOS R6 Mark II ([@hijae](https://github.com/hijae))
 - Nikon
    - Nikon COOLPIX B600
+- Sony
+   - Sony ZV-1F
 - Mobile Devices (beta)
    - Android
    - iOS
@@ -70,12 +76,12 @@ Currently supported features in `furble`:
 
 ### Table of Features
 
-| &nbsp; | Fujifilm X & GFX | Canon EOS M6 | Canon EOS R | Nikon COOLPIX | Android & iOS |
-| --- | :---: | :---: | :---: | :---: | :---: |
-| Scanning & Pairing | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
-| Shutter Release | ✔️ | ✔️ | ✔️ | ✔️ | ✔️|
-| Focus | ✔️ (see [#99](https://github.com/gkoh/furble/discussions/99)) | :x: | ✔️ | :x: | :x: |
-| GPS location tagging | ✔️ | :x: (WiFi only) | :x: | :x: | :x: |
+| &nbsp; | Fujifilm X & GFX | Canon EOS M6 | Canon EOS R | Nikon COOLPIX | Sony | Android & iOS |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: |
+| Scanning & Pairing | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Shutter Release | ✔️ | ✔️ | ✔️ | ✔️ | ✔️| ✔️ |
+| Focus | ✔️ (see [#99](https://github.com/gkoh/furble/discussions/99)) | :x: | ✔️ | :x: | ✔️ | :x: |
+| GPS location tagging | ✔️ | :x: (WiFi only) | :x: | :x: | ✔️ | :x: |
 
 ## Installation
 
@@ -323,6 +329,21 @@ mode has no support for GPS or focus functions, thus only shutter release works.
 Note that other Nikon cameras will appear in the scan, but will not pair
 (further support is under investigation).
 
+#### Sony
+
+Sony cameras appear to use a reasonably uniform and robust bluetooth control
+protocol. Most modern Sony cameras should be supported. Testing was performed
+on Sony ZV-1F.
+
+To pair with a Sony camera (some models may have different menu options, the
+following matches the ZV-1F):
+- set 'Bluetooth Rmt Ctrl' to 'On'
+- set 'Bluetooth Function' 'On'
+- under Bluetooth, start 'Pairing'
+- start 'Scan' with `furble'
+   - due to an oddity with the Bluetooth library, if `furble` 'Scan' is started
+     first, the Sony camera may not appear
+
 #### Protocol Reverse Engineering
 
 Android supports snooping bluetooth traffic so it was trivial to grab a HCI log
@@ -393,16 +414,21 @@ the following libraries:
 - improve the device matching and connection abstractions
   - especially if more cameras get supported
 - Support more camera makes and models
-   - Complete support for newer Canon EOS (eg. RP)
+   - Complete GPS support for newer Canon EOS (eg. RP)
    - Get access to and support the following:
-     - Sony
+     - Nikon Z
      - Others?
 
 # Links
 
-Inspiration for this project came from the following project/posts:
-- https://github.com/hkr/fuji-cam-wifi-tool
-- https://iandouglasscott.com/2017/09/04/reverse-engineering-the-canon-t7i-s-bluetooth-work-in-progress/
-
-Related projects:
-- https://github.com/ArthurFDLR/BR-M5
+Inspiration, references and related information for this project came from the following projects/posts:
+- Canon
+   - https://iandouglasscott.com/2017/09/04/reverse-engineering-the-canon-t7i-s-bluetooth-work-in-progress/
+   - https://github.com/ArthurFDLR/BR-M5
+   - https://github.com/RReverser/eos-remote-web
+- Fujifilm
+  - https://github.com/hkr/fuji-cam-wifi-tool
+- Sony
+   - https://gethypoxic.com/blogs/technical/sony-camera-ble-control-protocol-di-remote-control
+   - https://gregleeds.com/reverse-engineering-sony-camera-bluetooth
+   - https://github.com/Staacks/alpharemote

--- a/README.md
+++ b/README.md
@@ -76,12 +76,16 @@ Currently supported features in `furble`:
 
 ### Table of Features
 
-| &nbsp; | Fujifilm X & GFX | Canon EOS M6 | Canon EOS R | Nikon COOLPIX | Sony | Android & iOS |
-| --- | :---: | :---: | :---: | :---: | :---: | :---: |
-| Scanning & Pairing | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
-| Shutter Release | ✔️ | ✔️ | ✔️ | ✔️ | ✔️| ✔️ |
-| Focus | ✔️ (see [#99](https://github.com/gkoh/furble/discussions/99)) | :x: | ✔️ | :x: | ✔️ | :x: |
-| GPS location tagging | ✔️ | :x: (WiFi only) | :x: | :x: | ✔️ | :x: |
+| Camera | Scanning & Pairing | Shutter Release | Focus | GPS     |
+| :---:  | :---:              | :---:           | :---: | :---:   |
+| Fujifilm X & GFX | ✔️        | ✔️               | ✔️[^1] | ✔️       |
+| Canon EOS M6     | ✔️        | ✔️               | :x:   | :x:[^2] |
+| Canon EOS R      | ✔️        | ✔️               | ✔️     | :x:     |
+| Nikon COOLPIX    | ✔️        | ✔️               | :x:   | :x:     |
+| Sony ZV          | ✔️        | ✔️               | ✔️     | ✔️       |
+
+[^1]: see [#99](https://github.com/gkoh/furble/discussions/99)
+[^2]: WiFi only
 
 ## Installation
 
@@ -157,7 +161,7 @@ For slider and roller elements (eg. brightness control, intervalometer numbers):
 
 #### Touch Screen
 
-At time of writing, only the M5Core2 has been tested. All user interface widget are touch responsive:
+At time of writing, only the M5Core2 has been tested. All user interface widgets are touch responsive:
 * in menus
    * touch the desired entry
    * drag up/down to scroll entries
@@ -230,7 +234,7 @@ Connection to mobile devices is a little iffy:
 
 ### GPS Location Tagging
 
-For Fujifilm cameras, location tagging is supported with the M5Stack GPS unit:
+For Fujifilm & Sony cameras, location tagging is supported with the M5Stack GPS unit:
 - [GPS/BDS Unit v1.1 (AT6668)](https://shop.m5stack.com/products/gps-bds-unit-v1-1-at6668)
 
 The previous unit is now EOL:

--- a/lib/furble/Camera.h
+++ b/lib/furble/Camera.h
@@ -29,6 +29,7 @@ class Camera {
     MOBILE_DEVICE = 4,
     FAUXNY = 5,
     NIKON = 6,
+    SONY = 7,
   };
 
   enum class PairType : uint8_t {

--- a/lib/furble/CameraList.cpp
+++ b/lib/furble/CameraList.cpp
@@ -7,6 +7,7 @@
 #include "Fujifilm.h"
 #include "MobileDevice.h"
 #include "Nikon.h"
+#include "Sony.h"
 
 #include "CameraList.h"
 
@@ -168,6 +169,9 @@ void CameraList::load(void) {
       case Camera::Type::NIKON:
         m_ConnectList.push_back(std::unique_ptr<Furble::Camera>(new Nikon(dbuffer, dbytes)));
         break;
+      case Camera::Type::SONY:
+        m_ConnectList.push_back(std::unique_ptr<Furble::Camera>(new Sony(dbuffer, dbytes)));
+        break;
     }
   }
   m_Prefs.end();
@@ -209,6 +213,9 @@ bool CameraList::match(const NimBLEAdvertisedDevice *pDevice) {
     return true;
   } else if (Nikon::matches(pDevice)) {
     m_ConnectList.push_back(std::unique_ptr<Furble::Camera>(new Furble::Nikon(pDevice)));
+    return true;
+  } else if (Sony::matches(pDevice)) {
+    m_ConnectList.push_back(std::unique_ptr<Furble::Camera>(new Furble::Sony(pDevice)));
     return true;
   }
 

--- a/lib/furble/CanonEOS.cpp
+++ b/lib/furble/CanonEOS.cpp
@@ -24,7 +24,7 @@ CanonEOS::CanonEOS(Type type, const NimBLEAdvertisedDevice *pDevice) : Camera(ty
   m_Address = pDevice->getAddress();
   ESP_LOGI(LOG_TAG, "Name = %s", m_Name.c_str());
   ESP_LOGI(LOG_TAG, "Address = %s", m_Address.toString().c_str());
-  Device::getUUID128(&m_Uuid);
+  m_Uuid = Device::getUUID128();
 }
 
 void CanonEOS::_disconnect(void) {

--- a/lib/furble/Device.cpp
+++ b/lib/furble/Device.cpp
@@ -33,14 +33,17 @@ void Device::init(esp_power_level_t power) {
 
   m_ID = std::string(m_StringID);
 
+  // Combine address and data for scan duplicate detection
+  NimBLEDevice::setScanFilterMode(CONFIG_BTDM_SCAN_DUPL_TYPE_DATA_DEVICE);
+
   NimBLEDevice::init(m_ID);
   NimBLEDevice::setPower(power);
-  NimBLEDevice::setSecurityAuth(true, true, true);
+  NimBLEDevice::setSecurityAuth(true, false, true);
   // NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_PUBLIC);
 }
 
-void Device::getUUID128(uuid128_t *uuid) {
-  *uuid = m_Uuid;
+Device::uuid128_t Device::getUUID128(void) {
+  return m_Uuid;
 }
 
 const std::string Device::getStringID(void) {

--- a/lib/furble/Device.h
+++ b/lib/furble/Device.h
@@ -29,7 +29,7 @@ class Device {
   /**
    * Return a device consistent 128-bit UUID.
    */
-  static void getUUID128(uuid128_t *uuid);
+  static uuid128_t getUUID128(void);
 
   /**
    * Return pseudo-unique identifier string of this device.

--- a/lib/furble/Fujifilm.cpp
+++ b/lib/furble/Fujifilm.cpp
@@ -82,8 +82,8 @@ Fujifilm::Fujifilm(const NimBLEAdvertisedDevice *pDevice) : Camera(Type::FUJIFIL
  */
 bool Fujifilm::matches(const NimBLEAdvertisedDevice *pDevice) {
   if (pDevice->haveManufacturerData() && pDevice->getManufacturerData().length() == ADV_TOKEN_LEN) {
-    const char *data = pDevice->getManufacturerData().data();
-    if (data[0] == ID_0 && data[1] == ID_1 && data[2] == TYPE_TOKEN) {
+    const fujifilm_adv_t adv = pDevice->getManufacturerData<fujifilm_adv_t>();
+    if (adv.company_id == ID && adv.type_token == TYPE_TOKEN) {
       return true;
     }
   }

--- a/lib/furble/Fujifilm.h
+++ b/lib/furble/Fujifilm.h
@@ -28,15 +28,22 @@ class Fujifilm: public Camera {
   bool serialise(void *buffer, size_t bytes) const override final;
 
  protected:
-  bool _connect(void) override;
-  void _disconnect(void) override;
+  bool _connect(void) override final;
+  void _disconnect(void) override final;
 
  private:
   static constexpr size_t TOKEN_LEN = 4;
   static constexpr size_t ADV_TOKEN_LEN = 7;
-  static constexpr uint8_t ID_0 = 0xd8;
-  static constexpr uint8_t ID_1 = 0x04;
+  static constexpr uint16_t ID = 0x04d8;
   static constexpr uint8_t TYPE_TOKEN = 0x02;
+
+  /**
+   * Advertisement manufacturer data.
+   */
+  typedef struct __attribute__((packed)) {
+    uint16_t company_id;
+    uint8_t type_token;
+  } fujifilm_adv_t;
 
   /**
    * Time synchronisation.

--- a/lib/furble/Nikon.h
+++ b/lib/furble/Nikon.h
@@ -30,8 +30,8 @@ class Nikon: public Camera, public NimBLEScanCallbacks {
   bool serialise(void *buffer, size_t bytes) const override;
 
  protected:
-  bool _connect(void) override;
-  void _disconnect(void) override;
+  bool _connect(void) override final;
+  void _disconnect(void) override final;
 
  private:
   static constexpr uint16_t COMPANY_ID = 0x0399;

--- a/lib/furble/Sony.cpp
+++ b/lib/furble/Sony.cpp
@@ -1,0 +1,187 @@
+#include <NimBLEAddress.h>
+#include <NimBLEAdvertisedDevice.h>
+#include <NimBLEDevice.h>
+#include <NimBLERemoteCharacteristic.h>
+#include <NimBLERemoteService.h>
+#include <NimBLEUtils.h>
+
+#include "Sony.h"
+
+namespace Furble {
+
+Sony::Sony(const void *data, size_t len) : Camera(Type::SONY, PairType::SAVED) {
+  if (len != sizeof(sony_t))
+    abort();
+
+  const sony_t *sony = static_cast<const sony_t *>(data);
+  m_Name = std::string(sony->name);
+  m_Address = NimBLEAddress(sony->address, sony->type);
+  memcpy(&m_Uuid, &sony->uuid, sizeof(Device::uuid128_t));
+}
+
+Sony::Sony(const NimBLEAdvertisedDevice *pDevice) : Camera(Type::SONY, PairType::NEW) {
+  m_Name = pDevice->getName();
+  m_Address = pDevice->getAddress();
+  ESP_LOGI(LOG_TAG, "Name = %s", m_Name.c_str());
+  ESP_LOGI(LOG_TAG, "Address = %s", m_Address.toString().c_str());
+  m_Uuid = Device::getUUID128();
+}
+
+bool Sony::matches(const NimBLEAdvertisedDevice *pDevice) {
+  if (pDevice->haveManufacturerData()
+      && (pDevice->getManufacturerData().size() >= sizeof(sony_adv_t))) {
+    const sony_adv_t adv = pDevice->getManufacturerData<sony_adv_t>();
+    if (adv.company_id == ADV_SONY_ID && adv.type == ADV_SONY_CAMERA
+        && (adv.mode22
+            & (ADV_MODE22_PAIRING_SUPPORTED | ADV_MODE22_PAIRING_ENABLED
+               | ADV_MODE22_REMOTE_ENABLED))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool Sony::_connect(void) {
+  ESP_LOGI(LOG_TAG, "Connecting");
+  if (!m_Client->connect(m_Address)) {
+    ESP_LOGI(LOG_TAG, "Connection failed!!!");
+    return false;
+  }
+
+  ESP_LOGI(LOG_TAG, "Connected");
+  m_Progress = 20;
+
+  ESP_LOGI(LOG_TAG, "Securing");
+  if (!m_Client->secureConnection()) {
+    return false;
+  }
+  ESP_LOGI(LOG_TAG, "Secured!");
+  m_Progress = 40;
+
+  ESP_LOGI(LOG_TAG, "Retrieving control service!");
+  auto *pSvc = m_Client->getService(CTRL_SVC_UUID);
+  if (!pSvc) {
+    return false;
+  }
+  m_Progress = 60;
+
+  m_Control = pSvc->getCharacteristic(CTRL_CHR_UUID);
+  if (!m_Control) {
+    return false;
+  }
+  ESP_LOGI(LOG_TAG, "Retrieved control service!");
+  m_Progress = 80;
+
+  ESP_LOGI(LOG_TAG, "Retrieving location service");
+  m_GeoSvc = m_Client->getService(GEO_SVC_UUID);
+  if (m_GeoSvc != nullptr) {
+    ESP_LOGI(LOG_TAG, "Retrieved location service!");
+  }
+
+  m_Progress = 100;
+  ESP_LOGI(LOG_TAG, "Done!");
+
+  return true;
+}
+
+void Sony::_disconnect(void) {
+  m_Client->disconnect();
+  m_Connected = false;
+}
+
+void Sony::shutterPress(void) {
+  m_Control->writeValue(SHUTTER_DOWN, true);
+  return;
+}
+
+void Sony::shutterRelease(void) {
+  m_Control->writeValue(SHUTTER_UP, true);
+  return;
+}
+
+void Sony::focusPress(void) {
+  m_Control->writeValue(FOCUS_DOWN, true);
+  return;
+}
+
+void Sony::focusRelease(void) {
+  m_Control->writeValue(FOCUS_UP, true);
+}
+
+bool Sony::locationEnabled(void) {
+  if (m_GeoSvc) {
+    auto allowValue = m_GeoSvc->getValue(GEO_ALLOW_CHR_UUID);
+    auto enabledValue = m_GeoSvc->getValue(GEO_ENABLE_CHR_UUID);
+
+    if (allowValue.size() > 0 && enabledValue.size() > 0) {
+      uint8_t allow = allowValue.data()[0];
+      uint8_t enabled = enabledValue.data()[0];
+      // ESP_LOGI(LOG_TAG, "1: allow = %x, enabled = %x", allow, enabled);
+      if (allow != LOCATION_ALLOW && m_GeoSvc->setValue(GEO_ALLOW_CHR_UUID, {LOCATION_ALLOW})) {
+        allowValue = m_GeoSvc->getValue(GEO_ALLOW_CHR_UUID);
+        allow = allowValue.data()[0];
+        ESP_LOGI(LOG_TAG, "Location service allowed!");
+      }
+      if (enabled != LOCATION_ENABLE
+          && m_GeoSvc->setValue(GEO_ENABLE_CHR_UUID, {LOCATION_ENABLE})) {
+        enabledValue = m_GeoSvc->getValue(GEO_ENABLE_CHR_UUID);
+        enabled = enabledValue.data()[0];
+        ESP_LOGI(LOG_TAG, "Location service enabled!");
+      }
+
+      // auto info = m_GeoSvc->getValue(GEO_INFO_CHR_UUID);
+      // ESP_LOGI(LOG_TAG, "info = %s",
+      // NimBLEUtils::dataToHexString(info.data(), info.size()).c_str());
+
+      // ESP_LOGI(LOG_TAG, "2: allow = %x, enabled = %x", allow, enabled);
+      if (allow == LOCATION_ALLOW && enabled == LOCATION_ENABLE) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+void Sony::updateGeoData(const gps_t &gps, const timesync_t &timesync) {
+  if (locationEnabled()) {
+    sony_geo_t geo = {
+        .prefix = {0x00, 0x5d, 0x08, 0x02, 0xfc, 0x03, 0x00, 0x00, 0x10, 0x10, 0x10},
+        .latitude = (int32_t)__builtin_bswap32((uint32_t)(gps.latitude * 10000000)),
+        .longitude = (int32_t)__builtin_bswap32((uint32_t)(gps.longitude * 10000000)),
+        .year = __builtin_bswap16((uint16_t)timesync.year),
+        .month = (uint8_t)timesync.month,
+        .day = (uint8_t)timesync.day,
+        .hour = (uint8_t)timesync.hour,
+        .minute = (uint8_t)timesync.minute,
+        .second = (uint8_t)timesync.second,
+        .zero0 = {0x00},
+        .offset = __builtin_bswap16(0x0000),
+        .zero1 = {0x00},
+    };
+    // ESP_LOGI(LOG_TAG, "geo: %s", NimBLEUtils::dataToHexString((const uint8_t *)&geo,
+    // sizeof(geo)).c_str());
+    auto *pChr = m_GeoSvc->getCharacteristic(GEO_UPDATE_UUID);
+    pChr->writeValue((const uint8_t *)&geo, sizeof(geo), true);
+  }
+}
+
+size_t Sony::getSerialisedBytes(void) const {
+  return sizeof(sony_t);
+}
+
+bool Sony::serialise(void *buffer, size_t bytes) const {
+  if (bytes != sizeof(sony_t)) {
+    return false;
+  }
+  sony_t *x = static_cast<sony_t *>(buffer);
+  strncpy(x->name, m_Name.c_str(), MAX_NAME);
+  x->address = (uint64_t)m_Address;
+  x->type = m_Address.getType();
+  memcpy(&x->uuid, &m_Uuid, sizeof(Device::uuid128_t));
+
+  return true;
+}
+
+}  // namespace Furble

--- a/lib/furble/Sony.h
+++ b/lib/furble/Sony.h
@@ -1,0 +1,115 @@
+#ifndef SONY_H
+#define SONY_H
+
+#include "Camera.h"
+#include "Device.h"
+
+namespace Furble {
+/**
+ * Sony.
+ */
+class Sony: public Camera {
+ public:
+  Sony(const void *data, size_t len);
+  Sony(const NimBLEAdvertisedDevice *pDevice);
+
+  /**
+   * Determine if the advertised BLE device is a Sony.
+   */
+  static bool matches(const NimBLEAdvertisedDevice *pDevice);
+
+  void shutterPress(void) override final;
+  void shutterRelease(void) override final;
+  void focusPress(void) override final;
+  void focusRelease(void) override final;
+  void updateGeoData(const gps_t &gps, const timesync_t &timesync) override final;
+
+  size_t getSerialisedBytes(void) const override;
+  bool serialise(void *buffer, size_t bytes) const override;
+
+ private:
+  typedef struct _sony_t {
+    char name[MAX_NAME];    /** Human readable device name. */
+    uint64_t address;       /** Device MAC address. */
+    uint8_t type;           /** Address type. */
+    Device::uuid128_t uuid; /** Our UUID. */
+  } sony_t;
+
+  typedef struct __attribute__((packed)) {
+    uint16_t company_id;
+    uint16_t type;
+    uint8_t protocol_version;
+    uint8_t unused;
+    uint16_t model;
+    uint8_t tag22;
+    uint8_t mode22;
+    uint8_t zero0;
+    uint8_t tag21;
+    uint8_t mode21;
+  } sony_adv_t;
+
+  static const uint16_t ADV_SONY_ID = 0x012d;
+  static const uint16_t ADV_SONY_CAMERA = 0x0003;
+  static const uint8_t ADV_MODE22_PAIRING_SUPPORTED = (1 << 7);
+  static const uint8_t ADV_MODE22_PAIRING_ENABLED = (1 << 6);
+  static const uint8_t ADV_MODE22_LOCATION_SUPPORTED = (1 << 5);
+  static const uint8_t ADV_MODE22_LOCATION_ENABLED = (1 << 4);
+  static const uint8_t ADV_MODE22_UNKNOWN_00 = (1 << 3);
+  static const uint8_t ADV_MODE22_UNKNOWN_01 = (1 << 2);
+  static const uint8_t ADV_MODE22_REMOTE_ENABLED = (1 << 1);
+  static const uint8_t ADV_MODE22_UNKNOWN_02 = (1 << 0);
+
+  typedef struct __attribute__((packed)) {
+    uint8_t prefix[11];  // fixed prefix (005d0802fc030000101010)
+    int32_t latitude;    // *1e7
+    int32_t longitude;   // *1e7
+    uint16_t year;
+    uint8_t month;
+    uint8_t day;
+    uint8_t hour;
+    uint8_t minute;
+    uint8_t second;
+    uint8_t zero0[65];  // zero bytes
+    uint16_t offset;    // UTC offset in minutes
+    uint8_t zero1[2];   // zero bytes
+  } sony_geo_t;
+
+  // Primary service
+  const NimBLEUUID PRI_SVC_UUID {0x8000cc00, 0xcc00, 0xffff, 0xffffffffffffffff};
+
+  // Control service and characteristic (focus, shutter)
+  const NimBLEUUID CTRL_SVC_UUID {0x8000ff00, 0xff00, 0xffff, 0xffffffffffffffff};
+  const NimBLEUUID CTRL_CHR_UUID {(uint16_t)0xff01};
+
+  // Location service and characteristic
+  const NimBLEUUID GEO_SVC_UUID {0x8000dd00, 0xdd00, 0xffff, 0xffffffffffffffff};
+  const NimBLEUUID GEO_CHR_UUID {(uint16_t)0xdd01};
+  const NimBLEUUID GEO_UPDATE_UUID {(uint16_t)0xdd11};
+  const NimBLEUUID GEO_INFO_CHR_UUID {(uint16_t)0xdd21};
+  const NimBLEUUID GEO_ALLOW_CHR_UUID {(uint16_t)0xdd30};
+  const NimBLEUUID GEO_ENABLE_CHR_UUID {(uint16_t)0xdd31};
+
+  // Control commands
+  const uint16_t FOCUS_UP = 0x0601;
+  const uint16_t FOCUS_DOWN = 0x0701;
+  const uint16_t SHUTTER_UP = 0x0801;
+  const uint16_t SHUTTER_DOWN = 0x0901;
+
+  // Location commands
+  const uint8_t LOCATION_ALLOW = 0x01;
+  const uint8_t LOCATION_ENABLE = 0x01;
+
+  NimBLERemoteCharacteristic *m_Control = nullptr;
+  NimBLERemoteService *m_GeoSvc = nullptr;
+
+  Device::uuid128_t m_Uuid;
+
+  bool _connect(void) override final;
+  void _disconnect(void) override final;
+
+  // Check and enable location service
+  bool locationEnabled(void);
+};  // namespace Furble
+
+}  // namespace Furble
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ lib_deps =
   M5Unified@0.1.16
   lvgl/lvgl@9.2.2
   mikalhart/TinyGPSPlus@1.0.3
-  h2zero/NimBLE-Arduino@2.1.3
+  h2zero/NimBLE-Arduino@2.3.0
 
 [env:m5stick-c]
 board = m5stick-c


### PR DESCRIPTION
Initial pairing/bonding and re-connection working. Shutter and focus working.
Location service data working, UTC offset hardcoded to zero. Update README with Sony support.

Refactor Fujifilm advertisement handling for consistency.

Update NimBLE-Arduino to 2.3.0.