### PR TITLE
Use GitHub cache to improve CI performance.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,12 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
CI seems to consume a lot of time just installing platformio. Based on the platformio docs, try caching the packages.