### PR TITLE
Refactor Fujifilm into FujifilmBasic and FujifilmSecure.

### DIFF
--- a/lib/furble/Camera.h
+++ b/lib/furble/Camera.h
@@ -23,13 +23,14 @@ class Camera {
    * Camera types.
    */
   enum class Type : uint32_t {
-    FUJIFILM = 1,
+    FUJIFILM_BASIC = 1,
     CANON_EOS_M6 = 2,
     CANON_EOS_R = 3,
     MOBILE_DEVICE = 4,
     FAUXNY = 5,
     NIKON = 6,
     SONY = 7,
+    FUJIFILM_SECURE = 8,
   };
 
   enum class PairType : uint8_t {

--- a/lib/furble/CameraList.cpp
+++ b/lib/furble/CameraList.cpp
@@ -4,7 +4,8 @@
 #include "CanonEOSM6.h"
 #include "CanonEOSR.h"
 #include "FauxNY.h"
-#include "Fujifilm.h"
+#include "FujifilmBasic.h"
+#include "FujifilmSecure.h"
 #include "MobileDevice.h"
 #include "Nikon.h"
 #include "Sony.h"
@@ -151,8 +152,9 @@ void CameraList::load(void) {
     m_Prefs.getBytes(i.name, dbuffer, dbytes);
 
     switch (i.type) {
-      case Camera::Type::FUJIFILM:
-        m_ConnectList.push_back(std::unique_ptr<Furble::Camera>(new Fujifilm(dbuffer, dbytes)));
+      case Camera::Type::FUJIFILM_BASIC:
+        m_ConnectList.push_back(
+            std::unique_ptr<Furble::Camera>(new FujifilmBasic(dbuffer, dbytes)));
         break;
       case Camera::Type::CANON_EOS_M6:
         m_ConnectList.push_back(std::unique_ptr<Furble::Camera>(new CanonEOSM6(dbuffer, dbytes)));
@@ -171,6 +173,10 @@ void CameraList::load(void) {
         break;
       case Camera::Type::SONY:
         m_ConnectList.push_back(std::unique_ptr<Furble::Camera>(new Sony(dbuffer, dbytes)));
+        break;
+      case Camera::Type::FUJIFILM_SECURE:
+        m_ConnectList.push_back(
+            std::unique_ptr<Furble::Camera>(new FujifilmSecure(dbuffer, dbytes)));
         break;
     }
   }
@@ -202,8 +208,8 @@ Furble::Camera *CameraList::get(size_t n) {
 }
 
 bool CameraList::match(const NimBLEAdvertisedDevice *pDevice) {
-  if (Fujifilm::matches(pDevice)) {
-    m_ConnectList.push_back(std::unique_ptr<Furble::Camera>(new Furble::Fujifilm(pDevice)));
+  if (FujifilmBasic::matches(pDevice)) {
+    m_ConnectList.push_back(std::unique_ptr<Furble::Camera>(new Furble::FujifilmBasic(pDevice)));
     return true;
   } else if (CanonEOSM6::matches(pDevice)) {
     m_ConnectList.push_back(std::unique_ptr<Furble::Camera>(new Furble::CanonEOSM6(pDevice)));
@@ -216,6 +222,9 @@ bool CameraList::match(const NimBLEAdvertisedDevice *pDevice) {
     return true;
   } else if (Sony::matches(pDevice)) {
     m_ConnectList.push_back(std::unique_ptr<Furble::Camera>(new Furble::Sony(pDevice)));
+    return true;
+  } else if (FujifilmSecure::matches(pDevice)) {
+    m_ConnectList.push_back(std::unique_ptr<Furble::Camera>(new Furble::FujifilmSecure(pDevice)));
     return true;
   }
 

--- a/lib/furble/Fujifilm.cpp
+++ b/lib/furble/Fujifilm.cpp
@@ -14,10 +14,6 @@ constexpr std::array<uint8_t, 2> Fujifilm::SHUTTER_CMD;
 constexpr std::array<uint8_t, 2> Fujifilm::SHUTTER_PRESS;
 constexpr std::array<uint8_t, 2> Fujifilm::SHUTTER_FOCUS;
 
-void Fujifilm::print_token(const std::array<uint8_t, TOKEN_LEN> &token) {
-  ESP_LOGI(LOG_TAG, "Token = %02x%02x%02x%02x", token[0], token[1], token[2], token[3]);
-}
-
 void Fujifilm::notify(BLERemoteCharacteristic *pChr, uint8_t *pData, size_t length, bool isNotify) {
   ESP_LOGI(LOG_TAG, "Got %s callback: %u bytes from %s", isNotify ? "notification" : "indication",
            length, pChr->getUUID().toString().c_str());
@@ -57,138 +53,26 @@ bool Fujifilm::subscribe(const NimBLEUUID &svc, const NimBLEUUID &chr, bool noti
       true);
 }
 
-Fujifilm::Fujifilm(const void *data, size_t len) : Camera(Type::FUJIFILM, PairType::SAVED) {
-  if (len != sizeof(fujifilm_t))
-    abort();
-
-  const fujifilm_t *fujifilm = static_cast<const fujifilm_t *>(data);
-  m_Name = std::string(fujifilm->name);
-  m_Address = NimBLEAddress(fujifilm->address, fujifilm->type);
-  memcpy(m_Token.data(), fujifilm->token, TOKEN_LEN);
-}
-
-Fujifilm::Fujifilm(const NimBLEAdvertisedDevice *pDevice) : Camera(Type::FUJIFILM, PairType::NEW) {
-  const char *data = pDevice->getManufacturerData().data();
-  m_Name = pDevice->getName();
-  m_Address = pDevice->getAddress();
-  m_Token = {data[3], data[4], data[5], data[6]};
-  ESP_LOGI(LOG_TAG, "Name = %s", m_Name.c_str());
-  ESP_LOGI(LOG_TAG, "Address = %s", m_Address.toString().c_str());
-  print_token(m_Token);
-}
-
 /**
  * Determine if the advertised BLE device is a Fujifilm.
  */
 bool Fujifilm::matches(const NimBLEAdvertisedDevice *pDevice) {
-  if (pDevice->haveManufacturerData() && pDevice->getManufacturerData().length() == ADV_TOKEN_LEN) {
+  if (pDevice->haveManufacturerData()
+      && pDevice->getManufacturerData().length() >= sizeof(fujifilm_adv_t)) {
     const fujifilm_adv_t adv = pDevice->getManufacturerData<fujifilm_adv_t>();
-    if (adv.company_id == ID && adv.type_token == TYPE_TOKEN) {
+    if (adv.company_id == COMPANY_ID && adv.type == TYPE_TOKEN) {
       return true;
     }
   }
   return false;
 }
 
-/**
- * Connect to a Fujifilm.
- *
- * During initial pairing the advertisement includes a pairing token, this token
- * is what we use to identify ourselves upfront and during subsequent
- * re-pairing.
- */
-bool Fujifilm::_connect(void) {
-  m_Progress = 10;
-
-  NimBLERemoteService *pSvc = nullptr;
-  NimBLERemoteCharacteristic *pChr = nullptr;
-
-  ESP_LOGI(LOG_TAG, "Connecting");
-  if (!m_Client->connect(m_Address))
-    return false;
-
-  ESP_LOGI(LOG_TAG, "Connected");
-  m_Progress = 20;
-  pSvc = m_Client->getService(SVC_PAIR_UUID);
-  if (pSvc == nullptr)
-    return false;
-
-  ESP_LOGI(LOG_TAG, "Pairing");
-  pChr = pSvc->getCharacteristic(CHR_PAIR_UUID);
-  if (pChr == nullptr)
-    return false;
-
-  if (!pChr->canWrite())
-    return false;
-  print_token(m_Token);
-  if (!pChr->writeValue(m_Token.data(), m_Token.size(), true))
-    return false;
-  ESP_LOGI(LOG_TAG, "Paired!");
-  m_Progress = 30;
-
-  ESP_LOGI(LOG_TAG, "Identifying");
-  pChr = pSvc->getCharacteristic(CHR_IDEN_UUID);
-  if (!pChr->canWrite())
-    return false;
-  const auto name = Device::getStringID();
-  if (!pChr->writeValue(name.c_str(), name.length(), true))
-    return false;
-  ESP_LOGI(LOG_TAG, "Identified!");
-  m_Progress = 40;
-
-  // indications
-  ESP_LOGI(LOG_TAG, "Configuring");
-  if (!this->subscribe(SVC_CONF_UUID, CHR_IND1_UUID, false)) {
-    return false;
-  }
-
-  if (!this->subscribe(SVC_CONF_UUID, CHR_IND2_UUID, false)) {
-    return false;
-  }
-  m_Progress = 50;
-
-  // wait for up to (10*500)ms callback
-  for (unsigned int i = 0; i < 10; i++) {
-    if (m_Configured) {
-      break;
-    }
-    m_Progress = m_Progress.load() + 1;
-    vTaskDelay(pdMS_TO_TICKS(500));
-  }
-
-  m_Progress = 60;
-  // notifications
-  if (!this->subscribe(SVC_CONF_UUID, CHR_NOT1_UUID, true)) {
-    return false;
-  }
-  m_Progress = 70;
-
-  if (!this->subscribe(SVC_CONF_UUID, CHR_NOT2_UUID, true)) {
-    return false;
-  }
-  m_Progress = 80;
-
-  if (!this->subscribe(SVC_CONF_UUID, CHR_IND3_UUID, false)) {
-    return false;
-  }
-  m_Progress = 100;
-
-  ESP_LOGI(LOG_TAG, "Configured");
-  ESP_LOGI(LOG_TAG, "Connected");
-
-  return true;
-}
-
 template <std::size_t N>
 void Fujifilm::sendShutterCommand(const std::array<uint8_t, N> &cmd,
                                   const std::array<uint8_t, N> &param) {
-  NimBLERemoteService *pSvc = m_Client->getService(SVC_SHUTTER_UUID);
-  if (pSvc) {
-    NimBLERemoteCharacteristic *pChr = pSvc->getCharacteristic(CHR_SHUTTER_UUID);
-    if ((pChr != nullptr) && pChr->canWrite()) {
-      pChr->writeValue(cmd.data(), sizeof(cmd), true);
-      pChr->writeValue(param.data(), sizeof(cmd), true);
-    }
+  if (m_Shutter != nullptr && m_Shutter->canWrite()) {
+    m_Shutter->writeValue(cmd.data(), sizeof(cmd), true);
+    m_Shutter->writeValue(param.data(), sizeof(cmd), true);
   }
 }
 
@@ -257,23 +141,6 @@ void Fujifilm::updateGeoData(const gps_t &gps, const timesync_t &timesync) {
 void Fujifilm::_disconnect(void) {
   m_Client->disconnect();
   m_Connected = false;
-}
-
-size_t Fujifilm::getSerialisedBytes(void) const {
-  return sizeof(fujifilm_t);
-}
-
-bool Fujifilm::serialise(void *buffer, size_t bytes) const {
-  if (bytes != sizeof(fujifilm_t)) {
-    return false;
-  }
-  fujifilm_t *x = static_cast<fujifilm_t *>(buffer);
-  strncpy(x->name, m_Name.c_str(), MAX_NAME);
-  x->address = (uint64_t)m_Address;
-  x->type = m_Address.getType();
-  memcpy(x->token, m_Token.data(), TOKEN_LEN);
-
-  return true;
 }
 
 }  // namespace Furble

--- a/lib/furble/Fujifilm.h
+++ b/lib/furble/Fujifilm.h
@@ -11,12 +11,10 @@ namespace Furble {
  */
 class Fujifilm: public Camera {
  public:
-  Fujifilm(const void *data, size_t len);
-  Fujifilm(const NimBLEAdvertisedDevice *pDevice);
+  Fujifilm(Type type, const void *data, size_t len) : Camera(type, PairType::SAVED) {};
+  Fujifilm(Type type, const NimBLEAdvertisedDevice *pDevice) : Camera(type, PairType::NEW) {};
 
-  /**
-   * Determine if the advertised BLE device is a Fujifilm X-T30.
-   */
+  /** Is the advertised device a Fujifilm device? */
   static bool matches(const NimBLEAdvertisedDevice *pDevice);
 
   void shutterPress(void) override final;
@@ -24,26 +22,47 @@ class Fujifilm: public Camera {
   void focusPress(void) override final;
   void focusRelease(void) override final;
   void updateGeoData(const gps_t &gps, const timesync_t &timesync) override final;
-  size_t getSerialisedBytes(void) const override final;
-  bool serialise(void *buffer, size_t bytes) const override final;
 
  protected:
-  bool _connect(void) override final;
-  void _disconnect(void) override final;
-
- private:
-  static constexpr size_t TOKEN_LEN = 4;
-  static constexpr size_t ADV_TOKEN_LEN = 7;
-  static constexpr uint16_t ID = 0x04d8;
-  static constexpr uint8_t TYPE_TOKEN = 0x02;
-
   /**
    * Advertisement manufacturer data.
    */
   typedef struct __attribute__((packed)) {
     uint16_t company_id;
-    uint8_t type_token;
+    uint8_t type;
   } fujifilm_adv_t;
+
+  static constexpr uint16_t COMPANY_ID = 0x04d8;
+
+  // 0x4001
+  const NimBLEUUID SVC_PAIR_UUID {0x91f1de68, 0xdff6, 0x466e, 0x8b65ff13b0f16fb8};
+  // 0x4042
+  const NimBLEUUID CHR_PAIR_UUID {0xaba356eb, 0x9633, 0x4e60, 0xb73ff52516dbd671};
+  // 0x4012
+  const NimBLEUUID CHR_IDEN_UUID {0x85b9163e, 0x62d1, 0x49ff, 0xa6f5054b4630d4a1};
+
+  const NimBLEUUID SVC_CONF_UUID {0x4c0020fe, 0xf3b6, 0x40de, 0xacc977d129067b14};
+  // 0x5013
+  const NimBLEUUID CHR_IND1_UUID {0xa68e3f66, 0x0fcc, 0x4395, 0x8d4caa980b5877fa};
+  // 0x5023
+  const NimBLEUUID CHR_IND2_UUID {0xbd17ba04, 0xb76b, 0x4892, 0xa545b73ba1f74dae};
+  // 0x5033
+  const NimBLEUUID CHR_NOT1_UUID {0xf9150137, 0x5d40, 0x4801, 0xa8dcf7fc5b01da50};
+  // 0x5043
+  const NimBLEUUID CHR_NOT2_UUID {0xad06c7b7, 0xf41a, 0x46f4, 0xa29a712055319122};
+  const NimBLEUUID CHR_IND3_UUID {0x049ec406, 0xef75, 0x4205, 0xa39008fe209c51f0};
+
+  // Shutter characteristic
+  const NimBLEUUID CHR_SHUTTER_UUID {0x7fcf49c6, 0x4ff0, 0x4777, 0xa03d1a79166af7a8};
+
+  void _disconnect(void) override final;
+  bool subscribe(const NimBLEUUID &svc, const NimBLEUUID &chr, bool notifications);
+
+  bool m_Configured = false;
+  NimBLERemoteCharacteristic *m_Shutter = nullptr;
+
+ private:
+  static constexpr uint8_t TYPE_TOKEN = 0x02;
 
   /**
    * Time synchronisation.
@@ -68,40 +87,9 @@ class Fujifilm: public Camera {
     fujifilm_time_t gps_time;
   } geotag_t;
 
-  /**
-   * Non-volatile storage type.
-   */
-  typedef struct _fujifilm_t {
-    char name[MAX_NAME];      /** Human readable device name. */
-    uint64_t address;         /** Device MAC address. */
-    uint8_t type;             /** Address type. */
-    uint8_t token[TOKEN_LEN]; /** Pairing token. */
-  } fujifilm_t;
-
-  // 0x4001
-  const NimBLEUUID SVC_PAIR_UUID {0x91f1de68, 0xdff6, 0x466e, 0x8b65ff13b0f16fb8};
-  // 0x4042
-  const NimBLEUUID CHR_PAIR_UUID {0xaba356eb, 0x9633, 0x4e60, 0xb73ff52516dbd671};
-  // 0x4012
-  const NimBLEUUID CHR_IDEN_UUID {0x85b9163e, 0x62d1, 0x49ff, 0xa6f5054b4630d4a1};
-
   // Currently unused
   // const NimBLEUUID SVC_READ_UUID{0x4e941240, 0xd01d, 0x46b9, 0xa5ea67636806830b};
   // const NimBLEUUID CHR_READ_UUID{0xbf6dc9cf, 0x3606, 0x4ec9, 0xa4c8d77576e93ea4};
-
-  const NimBLEUUID SVC_CONF_UUID {0x4c0020fe, 0xf3b6, 0x40de, 0xacc977d129067b14};
-  // 0x5013
-  const NimBLEUUID CHR_IND1_UUID {0xa68e3f66, 0x0fcc, 0x4395, 0x8d4caa980b5877fa};
-  // 0x5023
-  const NimBLEUUID CHR_IND2_UUID {0xbd17ba04, 0xb76b, 0x4892, 0xa545b73ba1f74dae};
-  // 0x5033
-  const NimBLEUUID CHR_NOT1_UUID {0xf9150137, 0x5d40, 0x4801, 0xa8dcf7fc5b01da50};
-  // 0x5043
-  const NimBLEUUID CHR_NOT2_UUID {0xad06c7b7, 0xf41a, 0x46f4, 0xa29a712055319122};
-  const NimBLEUUID CHR_IND3_UUID {0x049ec406, 0xef75, 0x4205, 0xa39008fe209c51f0};
-
-  const NimBLEUUID SVC_SHUTTER_UUID {0x6514eb81, 0x4e8f, 0x458d, 0xaa2ae691336cdfac};
-  const NimBLEUUID CHR_SHUTTER_UUID {0x7fcf49c6, 0x4ff0, 0x4777, 0xa03d1a79166af7a8};
 
   const NimBLEUUID SVC_GEOTAG_UUID {0x3b46ec2b, 0x48ba, 0x41fd, 0xb1b8ed860b60d22b};
   const NimBLEUUID CHR_GEOTAG_UUID {0x0f36ec14, 0x29e5, 0x411a, 0xa1b664ee8383f090};
@@ -113,17 +101,11 @@ class Fujifilm: public Camera {
   static constexpr std::array<uint8_t, 2> SHUTTER_PRESS = {0x02, 0x00};
   static constexpr std::array<uint8_t, 2> SHUTTER_FOCUS = {0x03, 0x00};
 
-  void print_token(const std::array<uint8_t, TOKEN_LEN> &token);
   void notify(NimBLERemoteCharacteristic *, uint8_t *, size_t, bool);
-  bool subscribe(const NimBLEUUID &svc, const NimBLEUUID &chr, bool notifications);
   void sendGeoData(const gps_t &gps, const timesync_t &timesync);
 
   template <std::size_t N>
   void sendShutterCommand(const std::array<uint8_t, N> &cmd, const std::array<uint8_t, N> &param);
-
-  std::array<uint8_t, TOKEN_LEN> m_Token = {0};
-
-  bool m_Configured = false;
 
   volatile bool m_GeoRequested = false;
 };

--- a/lib/furble/FujifilmBasic.cpp
+++ b/lib/furble/FujifilmBasic.cpp
@@ -1,0 +1,176 @@
+#include <NimBLEAddress.h>
+#include <NimBLEAdvertisedDevice.h>
+#include <NimBLEDevice.h>
+#include <NimBLERemoteCharacteristic.h>
+#include <NimBLERemoteService.h>
+
+#include "Device.h"
+#include "FujifilmBasic.h"
+
+namespace Furble {
+
+const NimBLEUUID FujifilmBasic::PRI1_SVC_UUID {0xaf854c2e, 0xb214, 0x458e, 0x97e2912c4ecf2cb8};
+const NimBLEUUID FujifilmBasic::PRI2_SVC_UUID {0x117c4142, 0xedd4, 0x4c77, 0x8696dd18eebb770a};
+
+void FujifilmBasic::print_token(const std::array<uint8_t, TOKEN_LEN> &token) {
+  ESP_LOGI(LOG_TAG, "Token = %02x%02x%02x%02x", token[0], token[1], token[2], token[3]);
+}
+
+/**
+ * Determine if the advertised BLE device is a Fujifilm basic.
+ */
+bool FujifilmBasic::matches(const NimBLEAdvertisedDevice *pDevice) {
+  if (Fujifilm::matches(pDevice) && pDevice->getManufacturerData().length() == ADV_LEN) {
+    return pDevice->isAdvertisingService(PRI1_SVC_UUID)
+           || pDevice->isAdvertisingService(PRI2_SVC_UUID);
+  }
+
+  return false;
+}
+
+FujifilmBasic::FujifilmBasic(const void *data, size_t len)
+    : Fujifilm(Type::FUJIFILM_BASIC, data, len) {
+  if (len != sizeof(nvs_t))
+    abort();
+
+  const nvs_t *fujifilm = static_cast<const nvs_t *>(data);
+  m_Name = std::string(fujifilm->name);
+  m_Address = NimBLEAddress(fujifilm->address, fujifilm->type);
+  memcpy(m_Token.data(), fujifilm->token, TOKEN_LEN);
+}
+
+FujifilmBasic::FujifilmBasic(const NimBLEAdvertisedDevice *pDevice)
+    : Fujifilm(Type::FUJIFILM_BASIC, pDevice) {
+  const adv_basic_t adv = pDevice->getManufacturerData<adv_basic_t>();
+  m_Name = pDevice->getName();
+  m_Address = pDevice->getAddress();
+  m_Token = {adv.token[0], adv.token[1], adv.token[2], adv.token[3]};
+  ESP_LOGI(LOG_TAG, "Name = %s", m_Name.c_str());
+  ESP_LOGI(LOG_TAG, "Address = %s", m_Address.toString().c_str());
+  print_token(m_Token);
+}
+
+/**
+ * Connect to a Fujifilm basic camera.
+ *
+ * During initial pairing the advertisement includes a pairing token, this token
+ * is what we use to identify ourselves upfront and during subsequent
+ * re-pairing.
+ */
+bool FujifilmBasic::_connect(void) {
+  m_Progress = 10;
+
+  NimBLERemoteService *pSvc = nullptr;
+  NimBLERemoteCharacteristic *pChr = nullptr;
+
+  ESP_LOGI(LOG_TAG, "Connecting");
+  if (!m_Client->connect(m_Address))
+    return false;
+
+  ESP_LOGI(LOG_TAG, "Connected");
+  m_Progress = 20;
+  pSvc = m_Client->getService(SVC_PAIR_UUID);
+  if (pSvc == nullptr)
+    return false;
+
+  ESP_LOGI(LOG_TAG, "Pairing");
+  pChr = pSvc->getCharacteristic(CHR_PAIR_UUID);
+  if (pChr == nullptr)
+    return false;
+
+  if (!pChr->canWrite())
+    return false;
+  print_token(m_Token);
+  if (!pChr->writeValue(m_Token.data(), m_Token.size(), true))
+    return false;
+  ESP_LOGI(LOG_TAG, "Paired!");
+  m_Progress = 30;
+
+  ESP_LOGI(LOG_TAG, "Identifying");
+  pChr = pSvc->getCharacteristic(CHR_IDEN_UUID);
+  if (!pChr->canWrite())
+    return false;
+  const auto name = Device::getStringID();
+  if (!pChr->writeValue(name.c_str(), name.length(), true))
+    return false;
+  ESP_LOGI(LOG_TAG, "Identified!");
+  m_Progress = 40;
+
+  // indications
+  ESP_LOGI(LOG_TAG, "Configuring");
+  if (!this->subscribe(SVC_CONF_UUID, CHR_IND1_UUID, false)) {
+    return false;
+  }
+
+  if (!this->subscribe(SVC_CONF_UUID, CHR_IND2_UUID, false)) {
+    return false;
+  }
+  ESP_LOGI(LOG_TAG, "Configured");
+  m_Progress = 50;
+
+#if 0
+  // wait for up to (10*500)ms callback
+  for (unsigned int i = 0; i < 10; i++) {
+    if (m_Configured) {
+      break;
+    }
+    m_Progress = m_Progress.load() + 1;
+    vTaskDelay(pdMS_TO_TICKS(500));
+  }
+#endif
+
+  m_Progress = 60;
+  // notifications
+  if (!this->subscribe(SVC_CONF_UUID, CHR_NOT1_UUID, true)) {
+    return false;
+  }
+  m_Progress = 70;
+
+  if (!this->subscribe(SVC_CONF_UUID, CHR_NOT2_UUID, true)) {
+    return false;
+  }
+  m_Progress = 80;
+
+  if (!this->subscribe(SVC_CONF_UUID, CHR_IND3_UUID, false)) {
+    return false;
+  }
+
+  ESP_LOGI(LOG_TAG, "Getting shutter service");
+  pSvc = m_Client->getService(SVC_SHUTTER_UUID);
+  if (pSvc == nullptr) {
+    ESP_LOGI(LOG_TAG, "Failed to get shutter service");
+  }
+
+  m_Progress = 90;
+
+  ESP_LOGI(LOG_TAG, "Getting shutter characteristic");
+  m_Shutter = pSvc->getCharacteristic(CHR_SHUTTER_UUID);
+  if (m_Shutter == nullptr) {
+    ESP_LOGI(LOG_TAG, "Failed to get shutter characteristic");
+  }
+
+  m_Progress = 100;
+
+  ESP_LOGI(LOG_TAG, "Connected");
+
+  return true;
+}
+
+size_t FujifilmBasic::getSerialisedBytes(void) const {
+  return sizeof(nvs_t);
+}
+
+bool FujifilmBasic::serialise(void *buffer, size_t bytes) const {
+  if (bytes != sizeof(nvs_t)) {
+    return false;
+  }
+  nvs_t *x = static_cast<nvs_t *>(buffer);
+  strncpy(x->name, m_Name.c_str(), MAX_NAME);
+  x->address = (uint64_t)m_Address;
+  x->type = m_Address.getType();
+  memcpy(x->token, m_Token.data(), TOKEN_LEN);
+
+  return true;
+}
+
+}  // namespace Furble

--- a/lib/furble/FujifilmBasic.h
+++ b/lib/furble/FujifilmBasic.h
@@ -1,0 +1,66 @@
+#ifndef FUJIFILM_BASIC_H
+#define FUJIFILM_BASIC_H
+
+#include "Fujifilm.h"
+
+namespace Furble {
+/**
+ * Fujifilm basic.
+ *
+ * Unsecured communications. Originally for Fujifilm cameras, but no longer
+ * working for newer firmware with secured Bluetooth connections.
+ */
+class FujifilmBasic: public Fujifilm {
+ public:
+  FujifilmBasic(const void *data, size_t len);
+  FujifilmBasic(const NimBLEAdvertisedDevice *pDevice);
+
+  /**
+   * Determine if the advertised BLE device is a Fujifilm basic.
+   */
+  static bool matches(const NimBLEAdvertisedDevice *pDevice);
+
+  size_t getSerialisedBytes(void) const override final;
+  bool serialise(void *buffer, size_t bytes) const override final;
+
+ protected:
+  bool _connect(void) override final;
+
+ private:
+  static constexpr size_t ADV_LEN = 7;
+  static constexpr size_t TOKEN_LEN = 4;
+
+  /**
+   * Advertisement manufacturer data.
+   */
+  typedef struct __attribute__((packed)) {
+    fujifilm_adv_t adv;
+    uint8_t token[TOKEN_LEN];
+  } adv_basic_t;
+
+  /**
+   * Non-volatile storage type.
+   */
+  typedef struct _nvs_t {
+    char name[MAX_NAME];      /** Human readable device name. */
+    uint64_t address;         /** Device MAC address. */
+    uint8_t type;             /** Address type. */
+    uint8_t token[TOKEN_LEN]; /** Pairing token. */
+  } nvs_t;
+
+  // Primary service UUID
+  static const NimBLEUUID PRI1_SVC_UUID;
+
+  // Secondary service UUID
+  static const NimBLEUUID PRI2_SVC_UUID;
+
+  // Shutter service UUID
+  const NimBLEUUID SVC_SHUTTER_UUID {0x6514eb81, 0x4e8f, 0x458d, 0xaa2ae691336cdfac};
+
+  void print_token(const std::array<uint8_t, TOKEN_LEN> &token);
+
+  std::array<uint8_t, TOKEN_LEN> m_Token = {0};
+};
+
+}  // namespace Furble
+#endif

--- a/lib/furble/FujifilmSecure.cpp
+++ b/lib/furble/FujifilmSecure.cpp
@@ -1,0 +1,150 @@
+#include <NimBLEAddress.h>
+#include <NimBLEAdvertisedDevice.h>
+#include <NimBLEDevice.h>
+#include <NimBLERemoteCharacteristic.h>
+#include <NimBLERemoteService.h>
+
+#include "Device.h"
+#include "FujifilmSecure.h"
+
+namespace Furble {
+
+const NimBLEUUID FujifilmSecure::PRI_SVC_UUID {0x731893f9, 0x744e, 0x4899, 0xb7e3174106ff2b82};
+
+/**
+ * Determine if the advertised BLE device is a Fujifilm secure camera.
+ */
+bool FujifilmSecure::matches(const NimBLEAdvertisedDevice *pDevice) {
+  if (Fujifilm::matches(pDevice) && pDevice->isAdvertisingService(PRI_SVC_UUID)) {
+    return true;
+  }
+
+  return false;
+}
+
+FujifilmSecure::FujifilmSecure(const void *data, size_t len)
+    : Fujifilm(Type::FUJIFILM_SECURE, data, len) {
+  if (len != sizeof(nvs_t))
+    abort();
+
+  const nvs_t *fujifilm = static_cast<const nvs_t *>(data);
+  m_Name = std::string(fujifilm->name);
+  m_Address = NimBLEAddress(fujifilm->address, fujifilm->type);
+}
+
+FujifilmSecure::FujifilmSecure(const NimBLEAdvertisedDevice *pDevice)
+    : Fujifilm(Type::FUJIFILM_SECURE, pDevice) {
+  m_Name = pDevice->getName();
+  m_Address = pDevice->getAddress();
+  ESP_LOGI(LOG_TAG, "Name = %s", m_Name.c_str());
+  ESP_LOGI(LOG_TAG, "Address = %s", m_Address.toString().c_str());
+}
+
+bool FujifilmSecure::subscribeNotification(const NimBLEUUID &svc, const NimBLEUUID &chr) {
+  auto pSvc = m_Client->getService(svc);
+  if (pSvc == nullptr) {
+    return false;
+  }
+
+  auto pChr = pSvc->getCharacteristic(chr);
+  if (pChr == nullptr) {
+    return false;
+  }
+
+  return pChr->subscribe(
+      true,
+      [this](BLERemoteCharacteristic *pChr, uint8_t *pData, size_t length, bool isNotify) {
+        ESP_LOGI(LOG_TAG, "Notification received on %s", pChr->getUUID().toString().c_str());
+        if (length > 0) {
+          ESP_LOGI(LOG_TAG, " %s", NimBLEUtils::dataToHexString(pData, length).c_str());
+        }
+      },
+      true);
+}
+
+/**
+ * Connect to a Fujifilm secure.
+ */
+bool FujifilmSecure::_connect(void) {
+  m_Progress = 10;
+
+  // NimBLERemoteCharacteristic *pChr = nullptr;
+
+  ESP_LOGI(LOG_TAG, "Connecting");
+  if (!m_Client->connect(m_Address))
+    return false;
+
+  ESP_LOGI(LOG_TAG, "Connected");
+  m_Progress = 20;
+
+  ESP_LOGI(LOG_TAG, "Securing");
+  if (!m_Client->secureConnection()) {
+    return false;
+  }
+  ESP_LOGI(LOG_TAG, "Secured!");
+  m_Progress = 40;
+
+  ESP_LOGI(LOG_TAG, "Subscribing to notification 1");
+  if (!subscribeNotification(NOT1_SVC_UUID, NOT1_CHR_UUID)) {
+    return false;
+  }
+
+  ESP_LOGI(LOG_TAG, "Subscribing to notification 2");
+  if (!subscribeNotification(NOT1_SVC_UUID, NOT1_CHR_UUID)) {
+    return false;
+  }
+
+  ESP_LOGI(LOG_TAG, "Subscribing to notification 3");
+  if (!subscribeNotification(NOT1_SVC_UUID, NOT1_CHR_UUID)) {
+    return false;
+  }
+
+  ESP_LOGI(LOG_TAG, "Subscribing to notification 4");
+  if (!subscribeNotification(NOT1_SVC_UUID, NOT1_CHR_UUID)) {
+    return false;
+  }
+
+  ESP_LOGI(LOG_TAG, "Subscribing to notification 5");
+  if (!subscribeNotification(NOT1_SVC_UUID, NOT1_CHR_UUID)) {
+    return false;
+  }
+
+  ESP_LOGI(LOG_TAG, "Subscribing to notification 6");
+  if (!subscribeNotification(NOT1_SVC_UUID, NOT1_CHR_UUID)) {
+    return false;
+  }
+
+  ESP_LOGI(LOG_TAG, "Getting shutter service");
+  auto *pSvc = m_Client->getService(SHUTTER_SVC_UUID);
+  if (pSvc == nullptr) {
+    ESP_LOGI(LOG_TAG, "Failed to get shutter service");
+    return false;
+  }
+
+  ESP_LOGI(LOG_TAG, "Getting shutter characteristic");
+  m_Shutter = pSvc->getCharacteristic(CHR_SHUTTER_UUID);
+  if (m_Shutter == nullptr) {
+    ESP_LOGI(LOG_TAG, "Failed to get shutter characteristic");
+    return false;
+  }
+
+  return true;
+}
+
+size_t FujifilmSecure::getSerialisedBytes(void) const {
+  return sizeof(nvs_t);
+}
+
+bool FujifilmSecure::serialise(void *buffer, size_t bytes) const {
+  if (bytes != sizeof(nvs_t)) {
+    return false;
+  }
+  nvs_t *x = static_cast<nvs_t *>(buffer);
+  strncpy(x->name, m_Name.c_str(), MAX_NAME);
+  x->address = (uint64_t)m_Address;
+  x->type = m_Address.getType();
+
+  return true;
+}
+
+}  // namespace Furble

--- a/lib/furble/FujifilmSecure.h
+++ b/lib/furble/FujifilmSecure.h
@@ -1,0 +1,66 @@
+#ifndef FUJIFILM_SECURE_H
+#define FUJIFILM_SECURE_H
+
+#include <NimBLEUUID.h>
+
+#include "Fujifilm.h"
+
+namespace Furble {
+/**
+ * Fujifilm secure.
+ *
+ * Secured Bluetooth communications. For cameras running newer firmware from
+ * circa July 2025 onwards.
+ */
+class FujifilmSecure: public Fujifilm {
+ public:
+  FujifilmSecure(const void *data, size_t len);
+  FujifilmSecure(const NimBLEAdvertisedDevice *pDevice);
+
+  /**
+   * Determine if the advertised BLE device is a Fujifilm secure camera.
+   */
+  static bool matches(const NimBLEAdvertisedDevice *pDevice);
+
+  size_t getSerialisedBytes(void) const override final;
+  bool serialise(void *buffer, size_t bytes) const override final;
+
+ protected:
+  bool _connect(void) override final;
+
+ private:
+  /**
+   * Non-volatile storage type.
+   */
+  typedef struct _nvs_t {
+    char name[MAX_NAME]; /** Human readable device name. */
+    uint64_t address;    /** Device MAC address. */
+    uint8_t type;        /** Address type. */
+  } nvs_t;
+
+  // Primary service UUID
+  static const NimBLEUUID PRI_SVC_UUID;
+
+  // Unknown service UUID
+  const NimBLEUUID UNK0_SVC_UUID {0x123d8f06, 0x62a1, 0x4935, 0x9322833c531ee225};
+
+  // Service UUID for NOT1
+  const NimBLEUUID NOT1_SVC_UUID {0x4c0020fe, 0xf3b6, 0x40de, 0xacc977d129067b14};
+  const NimBLEUUID NOT1_CHR_UUID {0xe6692c5c, 0xb7cd, 0x44f4, 0x95fceda07ce32560};
+
+  // Service UUID for other notifications
+  const NimBLEUUID NOTX_SVC_UUID {0x4e941240, 0xd01d, 0x46b9, 0xa5ea67636806830b};
+  const NimBLEUUID NOT2_CHR_UUID {0xaab609c4, 0x94dd, 0x4d89, 0xbc60665d5090b828};
+  const NimBLEUUID NOT3_CHR_UUID {0x2a125640, 0x706d, 0x4dd1, 0xb420c0f4ab93c361};
+  const NimBLEUUID NOT4_CHR_UUID {0x82a9f452, 0xc5ce, 0x4ef5, 0x82033fc9a47f8171};
+  const NimBLEUUID NOT5_CHR_UUID {0xdeef7187, 0x3f43, 0x4364, 0x9e2211a8c8a15951};
+  const NimBLEUUID NOT6_CHR_UUID {0xc95d91ae, 0xb247, 0x4d6d, 0x86617dd5d6a0f85b};
+
+  // Shutter service UUID
+  const NimBLEUUID SHUTTER_SVC_UUID {0x6514eb81, 0x4e8f, 0x458d, 0xaa2ae691336cdfac};
+
+  bool subscribeNotification(const NimBLEUUID &svc, const NimBLEUUID &chr);
+};
+
+}  // namespace Furble
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ build_flags = -Wall -Wextra
   -DLV_CONF_PATH="\"${platformio.include_dir}/lv_conf.h\""
 
 [env]
-platform = espressif32
+platform = espressif32@6.11.0
 board_build.f_cpu = 80000000L
 upload_protocol = esptool
 framework = arduino, espidf


### PR DESCRIPTION
Cut the Fujifilm implementation into two pieces:
* FujifilmBasic: for the original, unsecure implementation
* FujifilmSecure: for the newer, secure implementation

Also, disable the `m_Configured` check, this appears deprecated.