### PR TITLE
Fix finding client during disconnect event.

### DIFF
--- a/patches/apply.py
+++ b/patches/apply.py
@@ -3,11 +3,16 @@ from os.path import join, relpath
 
 Import("env")
 
-def apply_patches(source, target, env):
+def apply_ble_gap_patch(source, target, env):
   env.Execute("{} --verbose -N -p1 -i {} {}".format("patch", "patches/ble_gap.patch", source[0]))
+
+def apply_ble_gap_disconnect_event_patch(source, target, env):
+  env.Execute("{} --verbose -N -p1 -i {} {}".format("patch", "patches/ble_gap_handle_disconnect_event.patch", source[0]))
 
 for lib in env.GetLibBuilders():
   if lib.name == "NimBLE-Arduino":
     build_dir = relpath(env.subst(lib.build_dir), get_project_dir())
     tgt_path = join(build_dir, "nimble", "nimble", "host", "src", "ble_gap.c.o")
-    env.AddPreAction(tgt_path, apply_patches)
+    env.AddPreAction(tgt_path, apply_ble_gap_patch)
+    tgt_path = join(build_dir, "NimBLEClient.cpp.o")
+    env.AddPreAction(tgt_path, apply_ble_gap_disconnect_event_patch)

--- a/patches/ble_gap_handle_disconnect_event.patch
+++ b/patches/ble_gap_handle_disconnect_event.patch
@@ -1,0 +1,15 @@
+--- src/NimBLEClient.cpp.orig	2025-09-06 11:37:45.147160424 +0930
++++ src/NimBLEClient.cpp	2025-09-06 11:39:00.454149508 +0930
+@@ -934,11 +934,7 @@
+     switch (event->type) {
+         case BLE_GAP_EVENT_DISCONNECT: {
+ 
+-            // workaround for bug in NimBLE stack where disconnect event argument is not passed correctly
+-            pClient = NimBLEDevice::getClientByPeerAddress(event->disconnect.conn.peer_ota_addr);
+-            if (pClient == nullptr) {
+-                pClient = NimBLEDevice::getClientByPeerAddress(event->disconnect.conn.peer_id_addr);
+-            }
++            pClient = NimBLEDevice::getClientByHandle(event->disconnect.conn.conn_handle);
+ 
+             if (pClient == nullptr) {
+                 NIMBLE_LOGE(LOG_TAG, "Disconnected client not found, conn_handle=%d",


### PR DESCRIPTION
With target RPA active, addresses change before connection and after identify resolution.
This resulted in a failure to find the right client handle when searching by peer address.

Fix this by finding the client by connection handle.