### PR TITLE
Revert some minor changes to FujifilmBasic.

### DIFF
--- a/lib/furble/Camera.cpp
+++ b/lib/furble/Camera.cpp
@@ -40,11 +40,11 @@ bool Camera::connect(esp_power_level_t power, uint32_t timeout) {
 
   // adjust connection timeout and parameters
   m_Client->setConnectTimeout(timeout);
-  // try extending range by adjusting connection parameters
-  m_Client->setConnectionParams(m_MinInterval, m_MaxInterval, m_Latency, m_Timeout);
 
   bool connected = this->_connect();
   if (connected) {
+    // try extending range by adjusting connection parameters
+    m_Client->updateConnParams(m_MinInterval, m_MaxInterval, m_Latency, m_Timeout);
     m_Paired = true;
   } else {
     this->_disconnect();

--- a/lib/furble/Fujifilm.h
+++ b/lib/furble/Fujifilm.h
@@ -64,7 +64,7 @@ class Fujifilm: public Camera {
   void _disconnect(void) override final;
   bool subscribe(const NimBLEUUID &svc, const NimBLEUUID &chr, bool notification);
 
-  bool m_Configured = false;
+  volatile bool m_Configured = false;
   NimBLERemoteCharacteristic *m_Shutter = nullptr;
 
  private:

--- a/lib/furble/FujifilmBasic.cpp
+++ b/lib/furble/FujifilmBasic.cpp
@@ -113,16 +113,14 @@ bool FujifilmBasic::_connect(void) {
   ESP_LOGI(LOG_TAG, "Configured");
   m_Progress = 50;
 
-#if 0
-  // wait for up to (10*500)ms callback
+  // wait for up to (10*100)ms callback
   for (unsigned int i = 0; i < 10; i++) {
     if (m_Configured) {
       break;
     }
     m_Progress = m_Progress.load() + 1;
-    vTaskDelay(pdMS_TO_TICKS(500));
+    vTaskDelay(pdMS_TO_TICKS(100));
   }
-#endif
 
   m_Progress = 60;
   // notifications


### PR DESCRIPTION
Reinstate the 'configured' check, which may/may not be necessary. Perform connection parameter updating after connection establishment, as before.

These changes attempt to make FujifilmBasic as close as possible to pre-FujifilmSecure handling.