### PR TITLE
Add initial wait to intervalometer.

### DIFF
--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -108,8 +108,9 @@ class UI {
 
     typedef enum {
       STATE_IDLE,
-      STATE_SHUTTER_OPEN,
       STATE_WAIT,
+      STATE_SHUTTER_OPEN,
+      STATE_DELAY,
       STATE_FINISHED,
     } state_t;
 
@@ -121,6 +122,7 @@ class UI {
     Spinner m_Count;
     Spinner m_Delay;
     Spinner m_Shutter;
+    Spinner m_Wait;
   };
 
   typedef enum { MODE_SCAN, MODE_DELETE, MODE_CONNECT, MODE_MULTICONNECT } CameraListMode_t;
@@ -183,6 +185,7 @@ class UI {
   static constexpr const char *m_IntervalCountStr = "Count";
   static constexpr const char *m_IntervalDelayStr = "Delay";
   static constexpr const char *m_IntervalShutterStr = "Shutter";
+  static constexpr const char *m_IntervalWaitStr = "Wait";
 
   static constexpr uint8_t BYTES_PER_PIXEL = (LV_COLOR_FORMAT_GET_SIZE(LV_COLOR_FORMAT_RGB565));
   static constexpr int32_t MAX_WIDTH = 320;

--- a/include/interval.h
+++ b/include/interval.h
@@ -5,14 +5,28 @@
 
 namespace Furble {
 
+constexpr SpinValue::nvs_t INTERVAL_DEFAULT_WAIT = {0, SpinValue::UNIT_SEC};
 constexpr SpinValue::nvs_t INTERVAL_DEFAULT_COUNT = {10, SpinValue::UNIT_NIL};
 constexpr SpinValue::nvs_t INTERVAL_DEFAULT_DELAY = {15, SpinValue::UNIT_SEC};
 constexpr SpinValue::nvs_t INTERVAL_DEFAULT_SHUTTER = {30, SpinValue::UNIT_MS};
 
+/**
+ * Version 1 of the NVS interval setting.
+ */
 typedef struct __attribute__((packed)) {
   SpinValue::nvs_t count;
   SpinValue::nvs_t delay;
   SpinValue::nvs_t shutter;
+} interval_v1_t;
+
+/**
+ * Current version of the NVS interval setting.
+ */
+typedef struct __attribute__((packed)) {
+  SpinValue::nvs_t count;
+  SpinValue::nvs_t delay;
+  SpinValue::nvs_t shutter;
+  SpinValue::nvs_t wait;
 } interval_t;
 
 }  // namespace Furble

--- a/src/FurbleSettings.cpp
+++ b/src/FurbleSettings.cpp
@@ -74,11 +74,15 @@ interval_t Settings::load<interval_t>(type_t type) {
 
   m_Prefs.begin(setting.nvs_namespace, true);
   size_t len = m_Prefs.get(setting.key, &interval, sizeof(interval_t));
-  if (len != sizeof(interval_t)) {
+  if (len == sizeof(interval_v1_t)) {
+    // migrate v1 interval settings
+    interval.wait = INTERVAL_DEFAULT_WAIT;
+  } else if (len != sizeof(interval_t)) {
     // default values
     interval.count = INTERVAL_DEFAULT_COUNT;
-    interval.shutter = INTERVAL_DEFAULT_SHUTTER;
     interval.delay = INTERVAL_DEFAULT_DELAY;
+    interval.shutter = INTERVAL_DEFAULT_SHUTTER;
+    interval.wait = INTERVAL_DEFAULT_WAIT;
   }
 
   m_Prefs.end();

--- a/src/FurbleUIIntervalometer.cpp
+++ b/src/FurbleUIIntervalometer.cpp
@@ -8,11 +8,12 @@ UI::Intervalometer::Intervalometer(const interval_t &interval)
     : m_State {STATE_IDLE},
       m_Count(this, interval.count, true),
       m_Delay(this, interval.delay),
-      m_Shutter(this, interval.shutter) {}
+      m_Shutter(this, interval.shutter),
+      m_Wait(this, interval.wait) {}
 
 void UI::Intervalometer::save(void) {
   interval_t interval = {m_Count.m_SpinValue.toNVS(), m_Delay.m_SpinValue.toNVS(),
-                         m_Shutter.m_SpinValue.toNVS()};
+                         m_Shutter.m_SpinValue.toNVS(), m_Wait.m_SpinValue.toNVS()};
   Settings::save<interval_t>(Settings::INTERVAL, interval);
 }
 


### PR DESCRIPTION
The intervalometer sequence is now:
- start
- wait (default 0 seconds)
- shutter
- delay
- go to shutter until count zero
- finish

NVS settings should migrate automatically and the default wait time is 0 seconds so existing behaviour is retained without intervention.