### PR TITLE
Auto connect on first power on. (#195)

### DIFF
--- a/include/FurbleSettings.h
+++ b/include/FurbleSettings.h
@@ -25,6 +25,7 @@ class Settings {
     RECONNECT,
     FAUXNY,
     TOUCH_CALIBRATION,
+    AUTOCONNECT,
   } type_t;
 
   typedef struct {

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -50,11 +50,6 @@ class UI {
   /** Unlock shutter. */
   void shutterUnlock(Control &control);
 
-  /** Is shutter locked? */
-  bool isShutterLocked(void);
-
-  bool m_FocusPressed = false;
-
  private:
   typedef struct {
     int32_t column;
@@ -254,8 +249,10 @@ class UI {
   Intervalometer m_Intervalometer;
 
   status_t m_Status;
+  bool m_FocusPressed = false;
   bool m_ShutterLock = false;
   uint32_t m_InactivityTimeout;
+  uint32_t m_MainCount = 0;
 
   static menu_t m_MainMenu;
 

--- a/src/FurbleSettings.cpp
+++ b/src/FurbleSettings.cpp
@@ -22,6 +22,7 @@ const std::unordered_map<Settings::type_t, Settings::setting_t> Settings::m_Sett
     {RECONNECT,         {RECONNECT, "Infinite-ReConnect", "reconnect", FURBLE_STR}     },
     {FAUXNY,            {FAUXNY, "FauxNY", "fauxNY", FURBLE_STR}                       },
     {TOUCH_CALIBRATION, {TOUCH_CALIBRATION, "Touch Calibration", "t_calib", FURBLE_STR}},
+    {AUTOCONNECT,       {AUTOCONNECT, "Auto-Connect", "autoconnect", FURBLE_STR}       },
 };
 
 const Settings::setting_t &Settings::get(type_t type) {
@@ -223,6 +224,7 @@ void Settings::init(void) {
         case MULTICONNECT:
         case RECONNECT:
         case FAUXNY:
+        case AUTOCONNECT:
           save<bool>(setting.type, false);
           break;
         case GPS_BAUD:

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -890,8 +890,11 @@ void UI::addMainMenu(void) {
         auto &scan = Scan::getInstance();
 
         if (page == m_MainMenu.page) {
+          size_t saveCount = CameraList::getSaveCount();
+          ui->m_MainCount++;
+
           // Hide connect & delete if there are zero saved
-          if (CameraList::getSaveCount() == 0) {
+          if (saveCount == 0) {
             lv_obj_add_state(m_Menu.at(m_ConnectStr).button, LV_STATE_DISABLED);
             lv_obj_add_state(m_Menu.at(m_DeleteStr).button, LV_STATE_DISABLED);
             lv_group_focus_obj(m_Menu.at(m_ScanStr).button);
@@ -906,6 +909,16 @@ void UI::addMainMenu(void) {
           // Enable Back button
           if (lv_obj_has_state(back, LV_STATE_DISABLED)) {
             lv_obj_remove_state(back, LV_STATE_DISABLED);
+          }
+
+          // If enabled and connections exist, auto connect to first camera on first display of main
+          // menu
+          if ((saveCount > 0) && (ui->m_MainCount == 1)
+              && Settings::load<bool>(Settings::AUTOCONNECT)) {
+            CameraList::load();
+            auto *camera = CameraList::get(0);
+            camera->setActive(true);
+            doConnect(e);
           }
         } else if (page == m_Menu.at(m_DeleteStr).page) {
         } else if (page == m_Menu.at(m_ScanStr).page) {
@@ -1596,6 +1609,7 @@ void UI::gpsDataStop(lv_event_t *e) {
 void UI::addFeaturesMenu(const menu_t &parent) {
   menu_t &menu = addMenu(m_FeaturesStr, &icon_wand_stars, true, parent);
 
+  addSettingItem(menu.page, NULL, Settings::AUTOCONNECT);
   addSettingItem(menu.page, NULL, Settings::FAUXNY);
   addSettingItem(menu.page, NULL, Settings::RECONNECT);
   addSettingItem(menu.page, NULL, Settings::MULTICONNECT);

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -533,10 +533,6 @@ void UI::shutterUnlock(Control &control) {
   }
 }
 
-bool UI::isShutterLocked(void) {
-  return m_ShutterLock;
-}
-
 void UI::handleShutter(lv_event_t *e) {
   auto *ui = static_cast<UI *>(lv_event_get_user_data(e));
   auto &control = Control::getInstance();
@@ -545,12 +541,12 @@ void UI::handleShutter(lv_event_t *e) {
     case LV_EVENT_PRESSED:
       if (ui->m_FocusPressed) {
         ui->shutterLock(control);
-      } else if (!ui->isShutterLocked()) {
+      } else if (!ui->m_ShutterLock) {
         control.sendCommand(Control::CMD_SHUTTER_PRESS);
       }
       break;
     case LV_EVENT_RELEASED:
-      if (ui->isShutterLocked()) {
+      if (ui->m_ShutterLock) {
         if (!ui->m_FocusPressed) {
           ui->shutterUnlock(control);
         }
@@ -570,7 +566,7 @@ void UI::handleFocus(lv_event_t *e) {
   switch (code) {
     case LV_EVENT_PRESSED:
       ui->m_FocusPressed = true;
-      if (ui->isShutterLocked()) {
+      if (ui->m_ShutterLock) {
         ui->shutterUnlock(control);
       } else {
         control.sendCommand(Control::CMD_FOCUS_PRESS);
@@ -578,7 +574,7 @@ void UI::handleFocus(lv_event_t *e) {
       break;
     case LV_EVENT_RELEASED:
       ui->m_FocusPressed = false;
-      if (!ui->isShutterLocked()) {
+      if (!ui->m_ShutterLock) {
         control.sendCommand(Control::CMD_FOCUS_RELEASE);
       }
       break;
@@ -599,7 +595,7 @@ void UI::handleShutterLock(lv_event_t *e) {
   switch (code) {
     case LV_EVENT_LONG_PRESSED:
       if (released) {
-        if (ui->isShutterLocked()) {
+        if (ui->m_ShutterLock) {
           ui->shutterUnlock(control);
         } else {
           ui->shutterLock(control);


### PR DESCRIPTION
If saved connections exist and 'Auto-Connect' is enabled, automatically
connect to the first saved camera on first power on.