### PR TITLE
Nikon: fix GPS payload struct and DMS sub-minute scaling

### DIFF
--- a/lib/furble/Nikon.cpp
+++ b/lib/furble/Nikon.cpp
@@ -455,14 +455,15 @@ void Nikon::updateGeoData(const gps_t &gps, const timesync_t &timesync) {
       .latitude_direction = gps.latitude < 0.0 ? 'S' : 'N',
       .latitude_degrees = 0,
       .latitude_minutes = 0,
-      .latitude_seconds = 0,
-      .latitude_fraction = 0,
+      .latitude_submin1 = 0,
+      .latitude_submin2 = 0,
       .longitude_direction = gps.longitude < 0.0 ? 'W' : 'E',
       .longitude_degrees = 0,
       .longitude_minutes = 0,
-      .longitude_seconds = 0,
-      .longitude_fraction = 0,
-      .extras = (uint16_t)gps.satellites,
+      .longitude_submin1 = 0,
+      .longitude_submin2 = 0,
+      .satellites = static_cast<uint8_t>(gps.satellites),
+      .altitude_ref = gps.altitude < 0.0 ? 'M' : 'P',
       .altitude = (uint16_t)gps.altitude,
       .time = ntime,
       .subseconds = (uint8_t)timesync.centisecond,
@@ -471,10 +472,10 @@ void Nikon::updateGeoData(const gps_t &gps, const timesync_t &timesync) {
       .pad = {0x00},
   };
 
-  degreesToDMS(gps.latitude, geo.latitude_degrees, geo.latitude_minutes, geo.latitude_seconds,
-               geo.latitude_fraction);
-  degreesToDMS(gps.longitude, geo.longitude_degrees, geo.longitude_minutes, geo.longitude_seconds,
-               geo.longitude_fraction);
+  degreesToDMSubMin(gps.latitude, geo.latitude_degrees, geo.latitude_minutes, geo.latitude_submin1,
+                    geo.latitude_submin2);
+  degreesToDMSubMin(gps.longitude, geo.longitude_degrees, geo.longitude_minutes,
+                    geo.longitude_submin1, geo.longitude_submin2);
 
   ESP_LOGI(LOG_TAG, "sending GPS = %s",
            NimBLEUtils::dataToHexString((const uint8_t *)&geo, sizeof(geo)).c_str());
@@ -490,23 +491,37 @@ void Nikon::_disconnect(void) {
   m_Client->disconnect();
 }
 
-void Nikon::degreesToDMS(double value,
-                         uint8_t &degrees,
-                         uint8_t &minutes,
-                         uint8_t &seconds,
-                         uint8_t &fraction) {
+// Converts a decimal-degree value into the Nikon encoding:
+// degrees, whole minutes, and two "sub-minute" bytes that
+// together represent the fractional minutes as a 4-digit number
+// (submin1 = hundredths of a minute, submin2 = hundredths of the
+// remainder).
+void Nikon::degreesToDMSubMin(double value,
+                              uint8_t &degrees,
+                              uint8_t &minutes,
+                              uint8_t &submin1,
+                              uint8_t &submin2) {
   double integral;
-  double fractional = std::modf(std::fabs(value), &integral);
+  double absValue = std::fabs(value);
+
+  // Whole degrees (truncated, matching Math.floor on a non-negative value).
+  std::modf(absValue, &integral);
   degrees = (uint8_t)integral;
-  fractional *= 60;
-  fractional = std::modf(fractional, &integral);
+
+  // Remaining fractional degrees, converted to minutes.
+  double minutesFull = (absValue - degrees) * 60.0;
+  std::modf(minutesFull, &integral);
   minutes = (uint8_t)integral;
-  fractional *= 60;
-  fractional = std::modf(fractional, &integral);
-  seconds = (uint8_t)integral;
-  fractional *= 10;
-  fractional = std::modf(fractional, &integral);
-  fraction = (uint8_t)integral;
+
+  // Remaining fractional minutes, scaled by 100
+  double subMinFull = (minutesFull - minutes) * 100.0;
+  std::modf(subMinFull, &integral);
+  submin1 = (uint8_t)integral;
+
+  // Remaining fractional hundredths-of-a-minute, scaled by 100 again.
+  double subMin2Full = (subMinFull - submin1) * 100.0;
+  std::modf(subMin2Full, &integral);
+  submin2 = (uint8_t)integral;
 }
 
 size_t Nikon::getSerialisedBytes(void) const {

--- a/lib/furble/Nikon.h
+++ b/lib/furble/Nikon.h
@@ -137,14 +137,15 @@ class Nikon: public Camera, public NimBLEScanCallbacks {
     uint8_t latitude_direction;  // {N|S}
     uint8_t latitude_degrees;
     uint8_t latitude_minutes;
-    uint8_t latitude_seconds;
-    uint8_t latitude_fraction;
+    uint8_t latitude_submin1;     // Remaining fractional minutes(hundredths of a minute)
+    uint8_t latitude_submin2;     // Remaining fractional hundredths-of-a-minute
     uint8_t longitude_direction;  // {E|W}
     uint8_t longitude_degrees;
     uint8_t longitude_minutes;
-    uint8_t longitude_seconds;
-    uint8_t longitude_fraction;
-    uint16_t extras;  // always 0x0050? no. of satellites
+    uint8_t longitude_submin1;  // Remaining fractional minutes(hundredths of a minute)
+    uint8_t longitude_submin2;  // Remaining fractional hundredths-of-a-minute
+    uint8_t satellites;         // no. of satellites
+    uint8_t altitude_ref;       // P=0x50 for positive, M=0x4D for negative altitude
     uint16_t altitude;
     nikon_time_t time;
     uint8_t subseconds;
@@ -227,13 +228,13 @@ class Nikon: public Camera, public NimBLEScanCallbacks {
   QueueHandle_t m_Queue;
 
   /**
-   * Convert decimal degrees to degrees, minutes, seconds and fraction.
+   * Convert decimal degrees to degrees, minutes and sub-minute parts.
    */
-  void degreesToDMS(double value,
-                    uint8_t &degrees,
-                    uint8_t &minutes,
-                    uint8_t &seconds,
-                    uint8_t &fraction);
+  void degreesToDMSubMin(double value,
+                         uint8_t &degrees,
+                         uint8_t &minutes,
+                         uint8_t &submin1,
+                         uint8_t &submin2);
 
   /** Advertised device has requisite service UUID. */
   static bool matchesServiceUUID(const NimBLEAdvertisedDevice *pDevice);


### PR DESCRIPTION
The nikon_geo_t struct merged "satellites" and "altitude_ref" into a single uint16_t "extras" field, leaving altitude_ref unset (0x00) instead of the required 'P'/'M' (0x50/0x4d). My camera (Z6III) rejects the write with ATT error 0x80 (rc: 384) whenever altitude_ref is invalid.

Split "extras" into separate satellites/altitude_ref bytes, and set altitude_ref from the sign of gps.altitude.

Also rename latitude/longitude_seconds/fraction to submin1/submin2 and switch degreesToDMS() (now degreesToDMSubMin()) from arc-second scaling (*60, *60, *10) to the hundredths-of-a-minute scaling Nikon actually expects (*60, *100, *100). The previous scaling sent plausible but measurably wrong coordinates ; the new scaling matches in-camera/EXIF position exactly.