### PR TITLE
refactor(camera): add per-camera BLE security mode virtual

### DIFF
--- a/lib/furble/Camera.cpp
+++ b/lib/furble/Camera.cpp
@@ -43,12 +43,17 @@ bool Camera::connect(esp_power_level_t power, uint32_t timeout) {
   // try extending range by adjusting connection parameters
   m_Client->setConnectionParams(m_MinInterval, m_MaxInterval, m_Latency, m_Timeout);
 
+  // set per-camera BLE security before connecting
+  NimBLEDevice::setSecurityAuth(true, true, true);
+  NimBLEDevice::setSecurityIOCap(static_cast<uint8_t>(securityMode()));
+
   bool connected = this->_connect();
   if (connected) {
     m_Paired = true;
   } else {
     this->_disconnect();
   }
+  NimBLEDevice::setSecurityIOCap(static_cast<uint8_t>(m_SecurityModeDefault));
 
   return m_Connected;
 }

--- a/lib/furble/Camera.h
+++ b/lib/furble/Camera.h
@@ -39,6 +39,11 @@ class Camera: public NimBLEClientCallbacks {
     SAVED = 2,
   };
 
+  enum class SecurityMode : uint8_t {
+    SECURE_DISPLAY_YESNO = BLE_HS_IO_DISPLAY_YESNO,
+    SECURE_KEYBOARD_DISPLAY = BLE_HS_IO_KEYBOARD_DISPLAY,
+  };
+
   /**
    * GPS data type.
    */
@@ -151,6 +156,15 @@ class Camera: public NimBLEClientCallbacks {
    */
   virtual void _disconnect(void) = 0;
 
+  /**
+   * BLE security IO capability for this camera type.
+   *
+   * @return the IO capability to advertise during pairing.
+   */
+  virtual SecurityMode securityMode() const {
+    return m_SecurityModeDefault;
+  }
+
   const PairType m_PairType;
   NimBLEAddress m_Address = NimBLEAddress {};
   NimBLEClient *m_Client = nullptr;
@@ -172,6 +186,8 @@ class Camera: public NimBLEClientCallbacks {
   // double the disconnect timeout
   const uint16_t m_Timeout = (2 * BLE_GAP_INITIAL_SUPERVISION_TIMEOUT);
   const Type m_Type;
+
+  static constexpr SecurityMode m_SecurityModeDefault = SecurityMode::SECURE_DISPLAY_YESNO;
 
   mutable std::mutex m_Mutex;
 

--- a/lib/furble/Camera.h
+++ b/lib/furble/Camera.h
@@ -161,9 +161,7 @@ class Camera: public NimBLEClientCallbacks {
    *
    * @return the IO capability to advertise during pairing.
    */
-  virtual SecurityMode securityMode() const {
-    return m_SecurityModeDefault;
-  }
+  virtual SecurityMode securityMode() const { return m_SecurityModeDefault; }
 
   const PairType m_PairType;
   NimBLEAddress m_Address = NimBLEAddress {};

--- a/lib/furble/Device.cpp
+++ b/lib/furble/Device.cpp
@@ -42,12 +42,6 @@ void Device::init(esp_power_level_t power) {
   NimBLEDevice::init(m_ID);
   NimBLEDevice::setPower(power);
 
-  // enable bonding, mitm and secure connection
-  NimBLEDevice::setSecurityAuth(true, true, true);
-
-  // claim YESNO to enable numeric LE security
-  NimBLEDevice::setSecurityIOCap(BLE_HS_IO_DISPLAY_YESNO);
-
   // configure RPA (where possible) and distribute encryption key and ID key (IRK)
   NimBLEDevice::setSecurityInitKey(BLE_SM_PAIR_KEY_DIST_ENC | BLE_SM_PAIR_KEY_DIST_ID);
   NimBLEDevice::setSecurityRespKey(BLE_SM_PAIR_KEY_DIST_ENC | BLE_SM_PAIR_KEY_DIST_ID);

--- a/lib/furble/Ricoh.cpp
+++ b/lib/furble/Ricoh.cpp
@@ -277,7 +277,6 @@ bool Ricoh::_connect(void) {
   subscribeCharacteristic(m_Power, "CameraPower");
   subscribeCharacteristic(m_OperationMode, "OperationMode");
 
-
   m_Progress = 100;
   ESP_LOGI(LOG_TAG, "Ricoh connected");
   return true;

--- a/lib/furble/Ricoh.cpp
+++ b/lib/furble/Ricoh.cpp
@@ -159,12 +159,12 @@ bool Ricoh::matches(const NimBLEAdvertisedDevice *pDevice) {
          || pDevice->isAdvertisingService(BT_CONTROL_SVC_UUID) || nameMatches(pDevice->getName());
 }
 
+Ricoh::SecurityMode Ricoh::securityMode() const {
+  return SecurityMode::SECURE_KEYBOARD_DISPLAY;
+}
+
 bool Ricoh::_connect(void) {
   m_Progress = 0;
-
-  constexpr uint8_t kDefaultIOCap = BLE_HS_IO_DISPLAY_YESNO;
-  NimBLEDevice::setSecurityIOCap(BLE_HS_IO_KEYBOARD_DISPLAY);
-  NimBLEDevice::setSecurityAuth(true, true, true);
 
   bool bondedBefore = NimBLEDevice::isBonded(m_Address);
   ESP_LOGI(LOG_TAG, "Ricoh bonded(before)=%s pairType=%s", bondedBefore ? "yes" : "no",
@@ -173,7 +173,6 @@ bool Ricoh::_connect(void) {
   ESP_LOGI(LOG_TAG, "Ricoh connecting");
   if (!m_Client->connect(m_Address)) {
     ESP_LOGI(LOG_TAG, "Ricoh connection failed");
-    NimBLEDevice::setSecurityIOCap(kDefaultIOCap);
     return false;
   }
   m_Progress = 15;
@@ -182,7 +181,6 @@ bool Ricoh::_connect(void) {
   if (!m_Client->secureConnection()) {
     ESP_LOGW(LOG_TAG, "Ricoh secure connection failed (bonded before=%s)",
              bondedBefore ? "yes" : "no");
-    NimBLEDevice::setSecurityIOCap(kDefaultIOCap);
     return false;
   }
   {
@@ -192,7 +190,6 @@ bool Ricoh::_connect(void) {
              connInfo.getSecKeySize());
     if (!connInfo.isEncrypted() || !connInfo.isAuthenticated() || !connInfo.isBonded()) {
       ESP_LOGW(LOG_TAG, "Ricoh secure link incomplete");
-      NimBLEDevice::setSecurityIOCap(kDefaultIOCap);
       return false;
     }
   }
@@ -223,7 +220,6 @@ bool Ricoh::_connect(void) {
   pSvc = m_Client->getService(SHOOTING_SVC_UUID);
   if (pSvc == nullptr) {
     ESP_LOGW(LOG_TAG, "Ricoh Shooting service unavailable");
-    NimBLEDevice::setSecurityIOCap(kDefaultIOCap);
     return false;
   }
 
@@ -233,12 +229,10 @@ bool Ricoh::_connect(void) {
   m_SelfTimer = pSvc->getCharacteristic(SELF_TIMER_CHR_UUID);
   if (m_OperationRequest == nullptr || !m_OperationRequest->canWrite()) {
     ESP_LOGW(LOG_TAG, "Ricoh OperationRequest unavailable");
-    NimBLEDevice::setSecurityIOCap(kDefaultIOCap);
     return false;
   }
   if (m_ShootingFlavor == nullptr || !m_ShootingFlavor->canWrite()) {
     ESP_LOGW(LOG_TAG, "Ricoh ShootingFlavor unavailable");
-    NimBLEDevice::setSecurityIOCap(kDefaultIOCap);
     return false;
   }
   m_Progress = 75;
@@ -283,7 +277,6 @@ bool Ricoh::_connect(void) {
   subscribeCharacteristic(m_Power, "CameraPower");
   subscribeCharacteristic(m_OperationMode, "OperationMode");
 
-  NimBLEDevice::setSecurityIOCap(kDefaultIOCap);
 
   m_Progress = 100;
   ESP_LOGI(LOG_TAG, "Ricoh connected");

--- a/lib/furble/Ricoh.h
+++ b/lib/furble/Ricoh.h
@@ -31,6 +31,8 @@ class Ricoh: public Camera {
   size_t getSerialisedBytes(void) const override final;
   bool serialise(void *buffer, size_t bytes) const override final;
 
+  SecurityMode securityMode() const override final;
+
  private:
   typedef struct _ricoh_t {
     char name[MAX_NAME];


### PR DESCRIPTION
Add virtual securityMode() to base Camera with default DISPLAY_YESNO. Ricoh overrides to KEYBOARD_DISPLAY.