### PR TITLE
Refactor Nikon protocol handling.

### DIFF
--- a/lib/furble/Nikon.cpp
+++ b/lib/furble/Nikon.cpp
@@ -1,4 +1,4 @@
-#include <cmath>
+#include <cstring>
 
 #include <NimBLEAddress.h>
 #include <NimBLEAdvertisedDevice.h>
@@ -8,187 +8,12 @@
 
 #include <esp_random.h>
 
-#include "Blowfish.h"
-#include "Device.h"
 #include "Nikon.h"
-
-#define NIKON_DEBUG (1)
+#include "NikonRemote.h"
+#include "NikonSmart.h"
+#include "Scan.h"
 
 namespace Furble {
-
-const std::vector<uint8_t> Nikon::SmartPairing::KEY = {0xff, 0xff, 0xaa, 0x55,
-                                                       0x11, 0x22, 0x33, 0x00};
-const std::array<std::array<uint32_t, 2>, 8> Nikon::SmartPairing::SALT = {
-    {
-     {0x704066e4u, 0x0433d552u},
-     {0xed4b8facu, 0x15f7e47bu},
-     {0x24471f11u, 0x8b5ea1fcu},
-     {0x05960c31u, 0x2b8c7f41u},
-     {0xfda588c1u, 0xeba8b1f3u},
-     {0x99166056u, 0x1bd3d550u},
-     {0xcd32687fu, 0xa9e28a30u},
-     {0x2a8fe834u, 0xdec7ebf4u},
-
-     }
-};
-const NimBLEUUID Nikon::SERVICE_UUID {0x0000de00, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-const std::array<uint8_t, 2> Nikon::SUCCESS = {0x01, 0x00};
-const std::array<uint8_t, 2> Nikon::GEO = {0x00, 0x01};
-
-Nikon::Pairing::Pairing(const Pairing::Type type, const uint64_t timestamp, const id_t id)
-    : m_Type(type) {
-  m_Stage[0].stage = 0x01;
-  m_Stage[0].timestamp = timestamp;
-  m_Stage[0].id = id;
-  m_Stage[1].stage = 0x02;
-  m_Stage[2].stage = 0x03;
-  m_Stage[3].stage = 0x04;
-  m_Stage[4].stage = 0x05;
-
-  m_Msg = &m_Stage[0];
-};
-
-const Nikon::Pairing::msg_t *Nikon::Pairing::getMessage(void) const {
-  return m_Msg;
-}
-
-Nikon::Pairing::Type Nikon::Pairing::getType(void) const {
-  return m_Type;
-}
-
-Nikon::RemotePairing::RemotePairing(const uint64_t timestamp, const Pairing::id_t &id)
-    : Pairing(Type::REMOTE, timestamp, id) {
-  m_Stage[1].timestamp = 0x00;
-  m_Stage[1].id = {0x00, 0x00};
-  m_Stage[2].timestamp = 0x00;
-  m_Stage[2].id = {0x00, 0x00};
-  m_Stage[3].timestamp = 0x00;
-  m_Stage[3].id = {0x00, 0x00};
-  m_Stage[4].timestamp = 0x00;
-  m_Stage[4].id = {0x00, 0x00};
-};
-
-const Nikon::Pairing::msg_t *Nikon::RemotePairing::processMessage(const msg_t &msg) {
-  switch (msg.stage) {
-    case 0:
-      m_Msg = &m_Stage[0];
-      return m_Msg;
-    case 2:
-    {
-      const msg_t *expected = &m_Stage[1];
-      if (memcmp(&msg, expected, sizeof(msg)) == 0) {
-        m_Msg = &m_Stage[2];
-        return m_Msg;
-      }
-    } break;
-    case 4:
-    {
-      if (msg.timestamp == m_Stage[3].timestamp) {
-        char serial[sizeof(msg.serial) + 1] = {0x00};
-        strncpy(serial, msg.serial, sizeof(serial) - 1);
-
-        ESP_LOGI(LOG_TAG, "Serial: %s", serial);
-        m_Msg = &m_Stage[4];
-        return m_Msg;
-      }
-    } break;
-  }
-
-  return nullptr;
-}
-
-Nikon::SmartPairing::SmartPairing(const uint64_t timestamp, const id_t id)
-    : Pairing(Type::SMART_DEVICE, timestamp, id), Blowfish(KEY) {
-  m_Stage[2].timestamp = timestamp;
-};
-
-void Nikon::SmartPairing::scramble(uint32_t *pL, uint32_t *pR) const {
-  uint32_t xL = *pL;
-  uint32_t xR = *pR;
-  uint32_t tmp = 0;
-
-  for (int i = 0; i < N; i++) {
-    tmp = xL ^ m_P[i];
-    xL = f(tmp) ^ xR;
-    xR = tmp;
-  }
-
-  *pL = tmp ^ m_P[N + 1];
-  *pR = xL ^ m_P[N];
-}
-
-std::array<uint32_t, 2> Nikon::SmartPairing::hash(const uint32_t *src, size_t len) const {
-  uint32_t right = 0x05060708;
-  uint32_t left = 0x01020304;
-  uint32_t inL = 0;
-  uint32_t inR = 0;
-
-  for (uint16_t i = 0; i < len; i += 2) {
-    inL = src[i] ^ left;
-    inR = src[i + 1] ^ right;
-    scramble(&inL, &inR);
-    left = inL;
-    right = inR;
-  }
-
-  return std::array<uint32_t, 2> {inL, inR};
-}
-
-int8_t Nikon::SmartPairing::findSaltIndex(const msg_t &msg) {
-  for (size_t i = 0; i < SALT.size(); i++) {
-    std::array<uint32_t, 6> s = {SALT[i][0],
-                                 SALT[i][1],
-                                 __builtin_bswap32(msg.timestampH),
-                                 __builtin_bswap32(msg.timestampL),
-                                 __builtin_bswap32(m_Stage[0].timestampH),
-                                 __builtin_bswap32(m_Stage[0].timestampL)};
-    std::array<uint32_t, 2> s2 = hash(s.data(), s.size());
-    if ((s2[0] == __builtin_bswap32(msg.id.device) && (s2[1] == __builtin_bswap32(msg.id.nonce)))) {
-      return i;
-    }
-  }
-  return -1;
-}
-
-const Nikon::Pairing::msg_t *Nikon::SmartPairing::processMessage(const msg_t &msg) {
-  switch (msg.stage) {
-    case 0:
-      m_Msg = &m_Stage[0];
-      return m_Msg;
-    case 2:
-    {
-      m_Salt = findSaltIndex(msg);
-      if (m_Salt >= 0) {
-        std::array<uint32_t, 6> buffer = {SALT[m_Salt][0],
-                                          SALT[m_Salt][1],
-                                          __builtin_bswap32(m_Stage[0].timestampH),
-                                          __builtin_bswap32(m_Stage[0].timestampL),
-                                          __builtin_bswap32(msg.timestampH),
-                                          __builtin_bswap32(msg.timestampL)};
-        std::array<uint32_t, 2> s3 = hash(buffer.data(), buffer.size());
-        m_Stage[2].id = {__builtin_bswap32(s3[0]), __builtin_bswap32(s3[1])};
-        m_Msg = &m_Stage[2];
-
-        m_Stage[3].timestamp = msg.timestamp;
-
-        return m_Msg;
-      }
-    } break;
-    case 4:
-    {
-      if (msg.timestamp == m_Stage[3].timestamp) {
-        char serial[sizeof(msg.serial) + 1] = {0x00};
-        strncpy(serial, msg.serial, sizeof(serial) - 1);
-
-        ESP_LOGI(LOG_TAG, "Serial: %s", serial);
-        m_Msg = &m_Stage[4];
-        return m_Msg;
-      }
-    } break;
-  }
-
-  return nullptr;
-}
 
 Nikon::Nikon(const void *data, size_t len) : Camera(Type::NIKON, PairType::SAVED) {
   if (len != sizeof(nikon_t))
@@ -198,7 +23,7 @@ Nikon::Nikon(const void *data, size_t len) : Camera(Type::NIKON, PairType::SAVED
   m_Name = std::string(nikon->name);
   m_Address = NimBLEAddress(nikon->address, nikon->type);
   esp_fill_random(&m_Timestamp, sizeof(m_Timestamp));
-  memcpy(&m_ID, &nikon->id, sizeof(m_ID));
+  std::memcpy(&m_ID, &nikon->id, sizeof(m_ID));
   m_Queue = xQueueCreate(3, sizeof(bool));
 }
 
@@ -218,7 +43,7 @@ Nikon::~Nikon(void) {
 }
 
 bool Nikon::matchesServiceUUID(const NimBLEAdvertisedDevice *pDevice) {
-  return (pDevice->haveServiceUUID() && (pDevice->getServiceUUID() == SERVICE_UUID));
+  return (pDevice->haveServiceUUID() && (pDevice->getServiceUUID() == NikonBase::SERVICE_UUID));
 }
 
 /**
@@ -276,252 +101,50 @@ bool Nikon::_connect(void) {
   ESP_LOGI(LOG_TAG, "Connected");
   m_Progress += 10;
 
-  auto *pSvc = m_Client->getService(SERVICE_UUID);
+  auto *pSvc = m_Client->getService(NikonBase::SERVICE_UUID);
   if (pSvc == nullptr) {
     return false;
   }
 
-  // try as remote connection first
-  m_PairChr = pSvc->getCharacteristic(REMOTE_PAIR_CHR_UUID);
-  if (m_PairChr == nullptr) {
-    // then try as smart device
-    m_PairChr = pSvc->getCharacteristic(PAIR_CHR_UUID);
-    if (m_PairChr == nullptr) {
+  // Try as remote first, then smart device. The pair characteristic found
+  // determines remote vs smart.
+  auto *pairChr = pSvc->getCharacteristic(NikonRemote::REMOTE_PAIR_CHR_UUID);
+  if (pairChr == nullptr) {
+    pairChr = pSvc->getCharacteristic(NikonSmart::PAIR_CHR_UUID);
+    if (pairChr == nullptr) {
       return false;
     }
-    m_Pairing = std::make_unique<SmartPairing>(m_Timestamp, m_ID);
-    ESP_LOGI(LOG_TAG, "Connecting as smart device, subscribing to success notification");
-    auto *pChr = pSvc->getCharacteristic(NOT1_CHR_UUID);
-    if (!pChr->subscribe(
-            true,
-            [this](NimBLERemoteCharacteristic *pBLERemoteCharacteristic, uint8_t *pData,
-                   size_t length, bool isNotify) {
-              bool rc = false;
-#if NIKON_DEBUG
-              ESP_LOGI(LOG_TAG, "data(not1) = %s",
-                       NimBLEUtils::dataToHexString(pData, length).c_str());
-#endif
-              if (memcmp(pData, SUCCESS.data(), length) == 0) {
-                rc = true;
-              }
-              xQueueSend(m_Queue, &rc, 0);
-            },
-            true)) {
-      return false;
-    }
-    ESP_LOGI(LOG_TAG, "Subscribed to success notification!");
+    m_Nikon =
+        std::make_unique<NikonSmart>(m_Client, m_Queue, pairChr, m_ID, m_Timestamp, &m_Progress);
   } else {
-    // Remote timestamp always seems to be 0x01
-    m_Pairing = std::make_unique<RemotePairing>(__builtin_bswap64(0x01), m_ID);
-    ESP_LOGI(LOG_TAG, "Connecting as remote, subscribing to indication 1");
-    auto *pChr = pSvc->getCharacteristic(REMOTE_IND1_CHR_UUID);
-    if (!pChr->subscribe(
-            false,
-            [this](NimBLERemoteCharacteristic *pBLERemoteCharacteristic, uint8_t *pData,
-                   size_t length, bool isNotify) {
-#if NIKON_DEBUG
-              ESP_LOGI(LOG_TAG, "data(ind1) = %s",
-                       NimBLEUtils::dataToHexString(pData, length).c_str());
-#endif
-            },
-            true)) {
-      return false;
-    }
-    ESP_LOGI(LOG_TAG, "Subscribed to indication 1!");
+    m_Nikon = std::make_unique<NikonRemote>(m_Client, m_Queue, pairChr, m_ID, &m_Progress);
   }
 
-  ESP_LOGI(LOG_TAG, "Subscribing to pairing indication");
-  if (!m_PairChr->subscribe(
-          false,
-          [this](NimBLERemoteCharacteristic *pBLERemoteCharacteristic, uint8_t *pData,
-                 size_t length, bool isNotify) {
-#if NIKON_DEBUG
-            ESP_LOGI(LOG_TAG, "data(stage) = %s",
-                     NimBLEUtils::dataToHexString(pData, length).c_str());
-#endif
-            Nikon::Pairing::msg_t msg;
-            memcpy(&msg, pData, sizeof(msg));
-            auto pMsg = this->m_Pairing->processMessage(msg);
-            bool rc = (pMsg != nullptr);
-            if (!rc) {
-              ESP_LOGI(LOG_TAG, "Stage response mismatch");
-            }
-            xQueueSend(m_Queue, &rc, 0);
-          },
-          true)) {
-    return false;
-  }
-  ESP_LOGI(LOG_TAG, "Subscribed to pairing indication!");
-
-  success = true;
-
-  // perform four stage handshake
-  for (uint8_t stage = 0; stage < 4 && success; stage += 2) {
-    const auto *msg = m_Pairing->getMessage();
-    if (!m_PairChr->writeValue((const uint8_t *)msg, sizeof(*msg), true)) {
-      return false;
-    }
-#if NIKON_DEBUG
-    ESP_LOGI(LOG_TAG, "sent = %s",
-             NimBLEUtils::dataToHexString((const uint8_t *)msg, sizeof(*msg)).c_str());
-#endif
-
-    // wait 10s for a notification
-    BaseType_t timeout = xQueueReceive(m_Queue, &success, pdMS_TO_TICKS(10000));
-    if (timeout == pdFALSE) {
-      success = false;
-      ESP_LOGI(LOG_TAG, "Timeout waiting for stage response.");
-      break;
-    }
-
-    m_Progress += 5;
-  }
-
-  if (!success) {
-    return false;
-  }
-
-  m_Progress += 10;
-
-  if (m_Pairing->getType() == Pairing::Type::SMART_DEVICE) {
-    // wait for final OK
-    BaseType_t timeout = xQueueReceive(m_Queue, &success, pdMS_TO_TICKS(10000));
-    if (timeout == pdFALSE) {
-      success = false;
-      ESP_LOGI(LOG_TAG, "Timeout waiting for final OK.");
-    }
-  } else {
-    success = true;
-  }
-
-  if (!success) {
-    return false;
-  }
-
-  if (m_Pairing->getType() == Pairing::Type::SMART_DEVICE) {
-    const auto name = Device::getStringID();
-    ESP_LOGI(LOG_TAG, "Identifying as %s", name.c_str());
-    if (!m_Client->setValue(SERVICE_UUID, ID_CHR_UUID, name, true)) {
-      return false;
-    }
-
-    // Unable to continue at this time
-    // For some reason Nikon smart device pairing swaps to Bluetooth Classic to
-    // establish secure bond and our Bluetooth stack is LE only.
-    ESP_LOGI(LOG_TAG, "Nikon smart device pairing not fully functional");
-
-    return false;
-  } else {
-    // nothing more needed for remote mode
-  }
-
-  ESP_LOGI(LOG_TAG, "%s", success ? "Done!" : "Failed to receive final OK.");
-
-  m_Progress = 100;
-
-  return success;
-}
-
-void Nikon::shutterPress(void) {
-  std::array<uint8_t, 2> cmd = {MODE_SHUTTER, CMD_PRESS};
-  m_Client->setValue(SERVICE_UUID, REMOTE_SHUTTER_CHR_UUID, {cmd.data(), cmd.size()}, true);
-}
-
-void Nikon::shutterRelease(void) {
-  std::array<uint8_t, 2> cmd = {MODE_SHUTTER, CMD_RELEASE};
-  m_Client->setValue(SERVICE_UUID, REMOTE_SHUTTER_CHR_UUID, {cmd.data(), cmd.size()}, true);
-}
-
-void Nikon::focusPress(void) {
-  // do nothing
-}
-
-void Nikon::focusRelease(void) {
-  // do nothing
-}
-
-void Nikon::updateGeoData(const gps_t &gps, const timesync_t &timesync) {
-  nikon_time_t ntime = {
-      .year = (uint16_t)timesync.year,
-      .month = (uint8_t)timesync.month,
-      .day = (uint8_t)timesync.day,
-      .hour = (uint8_t)timesync.hour,
-      .minute = (uint8_t)timesync.minute,
-      .second = (uint8_t)timesync.second,
-  };
-
-  nikon_geo_t geo = {
-      .header = 0x007f,
-      .latitude_direction = gps.latitude < 0.0 ? 'S' : 'N',
-      .latitude_degrees = 0,
-      .latitude_minutes = 0,
-      .latitude_submin1 = 0,
-      .latitude_submin2 = 0,
-      .longitude_direction = gps.longitude < 0.0 ? 'W' : 'E',
-      .longitude_degrees = 0,
-      .longitude_minutes = 0,
-      .longitude_submin1 = 0,
-      .longitude_submin2 = 0,
-      .satellites = static_cast<uint8_t>(gps.satellites),
-      .altitude_ref = gps.altitude < 0.0 ? 'M' : 'P',
-      .altitude = (uint16_t)gps.altitude,
-      .time = ntime,
-      .subseconds = (uint8_t)timesync.centisecond,
-      .valid = 0x01,
-      .standard = {'W', 'G', 'S', '-', '8', '4'},
-      .pad = {0x00},
-  };
-
-  degreesToDMSubMin(gps.latitude, geo.latitude_degrees, geo.latitude_minutes, geo.latitude_submin1,
-                    geo.latitude_submin2);
-  degreesToDMSubMin(gps.longitude, geo.longitude_degrees, geo.longitude_minutes,
-                    geo.longitude_submin1, geo.longitude_submin2);
-
-  ESP_LOGI(LOG_TAG, "sending GPS = %s",
-           NimBLEUtils::dataToHexString((const uint8_t *)&geo, sizeof(geo)).c_str());
-  if (m_Client->setValue(SERVICE_UUID, GEO_CHR_UUID, {(const uint8_t *)&geo, (uint16_t)sizeof(geo)},
-                         true)) {
-    ESP_LOGI(LOG_TAG, "  success");
-  } else {
-    ESP_LOGI(LOG_TAG, "  failed");
-  }
+  return m_Nikon->connect(pSvc);
 }
 
 void Nikon::_disconnect(void) {
   m_Client->disconnect();
 }
 
-// Converts a decimal-degree value into the Nikon encoding:
-// degrees, whole minutes, and two "sub-minute" bytes that
-// together represent the fractional minutes as a 4-digit number
-// (submin1 = hundredths of a minute, submin2 = hundredths of the
-// remainder).
-void Nikon::degreesToDMSubMin(double value,
-                              uint8_t &degrees,
-                              uint8_t &minutes,
-                              uint8_t &submin1,
-                              uint8_t &submin2) {
-  double integral;
-  double absValue = std::fabs(value);
+void Nikon::shutterPress(void) {
+  m_Nikon->shutterPress();
+}
 
-  // Whole degrees (truncated, matching Math.floor on a non-negative value).
-  std::modf(absValue, &integral);
-  degrees = (uint8_t)integral;
+void Nikon::shutterRelease(void) {
+  m_Nikon->shutterRelease();
+}
 
-  // Remaining fractional degrees, converted to minutes.
-  double minutesFull = (absValue - degrees) * 60.0;
-  std::modf(minutesFull, &integral);
-  minutes = (uint8_t)integral;
+void Nikon::focusPress(void) {
+  m_Nikon->focusPress();
+}
 
-  // Remaining fractional minutes, scaled by 100
-  double subMinFull = (minutesFull - minutes) * 100.0;
-  std::modf(subMinFull, &integral);
-  submin1 = (uint8_t)integral;
+void Nikon::focusRelease(void) {
+  m_Nikon->focusRelease();
+}
 
-  // Remaining fractional hundredths-of-a-minute, scaled by 100 again.
-  double subMin2Full = (subMinFull - submin1) * 100.0;
-  std::modf(subMin2Full, &integral);
-  submin2 = (uint8_t)integral;
+void Nikon::updateGeoData(const gps_t &gps, const timesync_t &timesync) {
+  m_Nikon->updateGeoData(gps, timesync);
 }
 
 size_t Nikon::getSerialisedBytes(void) const {
@@ -536,7 +159,7 @@ bool Nikon::serialise(void *buffer, size_t bytes) const {
   strncpy(x->name, m_Name.c_str(), MAX_NAME);
   x->address = (uint64_t)m_Address;
   x->type = m_Address.getType();
-  memcpy(&x->id, &m_ID, sizeof(x->id));
+  std::memcpy(&x->id, &m_ID, sizeof(x->id));
 
   return true;
 }

--- a/lib/furble/Nikon.h
+++ b/lib/furble/Nikon.h
@@ -1,15 +1,19 @@
 #ifndef NIKON_H
 #define NIKON_H
 
-#include <NimBLERemoteCharacteristic.h>
+#include <cstdint>
+#include <memory>
 
-#include "Blowfish.h"
 #include "Camera.h"
+#include "NikonBase.h"
 #include "Scan.h"
 
 namespace Furble {
 /**
- * Nikon Coolpix B600.
+ * Nikon camera support.
+ *
+ * Unifies both Remote and Smart protocols.
+ * Originally implemented and tested against Nikon Coolpix B600 in remote mode.
  */
 class Nikon: public Camera, public NimBLEScanCallbacks {
  public:
@@ -17,9 +21,7 @@ class Nikon: public Camera, public NimBLEScanCallbacks {
   Nikon(const NimBLEAdvertisedDevice *pDevice);
   ~Nikon();
 
-  /**
-   * Determine if the advertised BLE device is a Nikon Coolpix B600.
-   */
+  /** Determine if the advertised BLE device is a Nikon camera. */
   static bool matches(const NimBLEAdvertisedDevice *pDevice);
 
   void shutterPress(void) override;
@@ -35,73 +37,6 @@ class Nikon: public Camera, public NimBLEScanCallbacks {
   void _disconnect(void) override final;
 
  private:
-  class Pairing {
-   public:
-    enum class Type {
-      REMOTE,
-      SMART_DEVICE,
-    };
-
-    /** Identifier. */
-    typedef struct __attribute__((packed)) _id_t {
-      uint32_t device;  // sent in manufacturer data in reconnect
-      uint32_t nonce;
-    } id_t;
-
-    /** Pairing message. */
-    typedef struct __attribute__((packed)) _msg_t {
-      uint8_t stage;
-      union {
-        struct __attribute__((packed)) {
-          uint32_t timestampH;
-          uint32_t timestampL;
-        };
-        uint64_t timestamp;
-      };
-      union {
-        Pairing::id_t id;
-        char serial[8];
-      };
-    } msg_t;
-
-    virtual const msg_t *processMessage(const msg_t &msg) = 0;
-    const msg_t *getMessage(void) const;
-    Type getType(void) const;
-
-   protected:
-    Pairing(const Pairing::Type type, const uint64_t timestamp, const Pairing::id_t id);
-
-    msg_t *m_Msg = nullptr;
-    std::array<msg_t, 5> m_Stage;
-
-   private:
-    const Pairing::Type m_Type;
-  };
-
-  class RemotePairing: public Pairing {
-   public:
-    RemotePairing(const uint64_t timestamp, const Pairing::id_t &id);
-
-    const msg_t *processMessage(const msg_t &msg) final;
-  };
-
-  class SmartPairing: public Pairing, Blowfish {
-   public:
-    SmartPairing(const uint64_t timestamp, const Pairing::id_t id);
-
-    const msg_t *processMessage(const msg_t &msg) final;
-
-    std::array<uint32_t, 2> hash(const uint32_t *src, size_t len) const;
-
-   private:
-    void scramble(uint32_t *pL, uint32_t *pR) const;
-    int8_t findSaltIndex(const msg_t &msg);
-
-    static const std::vector<uint8_t> KEY;
-    static const std::array<std::array<uint32_t, 2>, 8> SALT;
-    int8_t m_Salt = -1;
-  };
-
   static constexpr uint16_t COMPANY_ID = 0x0399;
 
   /** Connect saved advertised manufacturer data. */
@@ -111,137 +46,26 @@ class Nikon: public Camera, public NimBLEScanCallbacks {
     uint8_t zero;
   } nikon_adv_t;
 
-  /** Time synchronisation. */
-  typedef struct __attribute__((packed)) _nikon_time_t {
-    uint16_t year;
-    uint8_t month;
-    uint8_t day;
-    uint8_t hour;
-    uint8_t minute;
-    uint8_t second;
-  } nikon_time_t;
-
-  // 10 bytes
-  typedef struct __attribute__((packed)) _timesync_msg_t {
-    nikon_time_t time;
-    uint8_t dst_offset;
-    uint8_t tz_offset_hours;
-    uint8_t tz_offset_minutes;
-  } timesync_msg_t;
-
-  // 41 bytes
-  /** Location synchronisation. */
-  typedef struct __attribute__((packed)) _nikon_geo_t {
-    uint16_t header;             // 0x7f00 = isLat | isLon | isSat | isAlt |
-                                 // isPos | isGps | isMap
-    uint8_t latitude_direction;  // {N|S}
-    uint8_t latitude_degrees;
-    uint8_t latitude_minutes;
-    uint8_t latitude_submin1;     // Remaining fractional minutes(hundredths of a minute)
-    uint8_t latitude_submin2;     // Remaining fractional hundredths-of-a-minute
-    uint8_t longitude_direction;  // {E|W}
-    uint8_t longitude_degrees;
-    uint8_t longitude_minutes;
-    uint8_t longitude_submin1;  // Remaining fractional minutes(hundredths of a minute)
-    uint8_t longitude_submin2;  // Remaining fractional hundredths-of-a-minute
-    uint8_t satellites;         // no. of satellites
-    uint8_t altitude_ref;       // P=0x50 for positive, M=0x4D for negative altitude
-    uint16_t altitude;
-    nikon_time_t time;
-    uint8_t subseconds;
-    uint8_t valid;        // 0x01 == valid
-    uint8_t standard[6];  // WGS-84
-    uint8_t pad[10];
-  } nikon_geo_t;
-
-  /**
-   * Non-volatile storage type.
-   */
+  /** Non-volatile storage type. */
   typedef struct _nikon_t {
-    char name[MAX_NAME]; /** Human readable device name. */
-    uint64_t address;    /** Device MAC address. */
-    uint8_t type;        /** Address type. */
-    Pairing::id_t id;    /** Unique identifiers. */
+    char name[MAX_NAME];         /** Human readable device name. */
+    uint64_t address;            /** Device MAC address. */
+    uint8_t type;                /** Address type. */
+    NikonBase::Pairing::id_t id; /** Unique identifiers. */
   } nikon_t;
 
   // Re-pair scan time
   static constexpr uint32_t SCAN_TIME_MS = 60000;
 
-  // Service UUID from advertisement data
-  static const NimBLEUUID SERVICE_UUID;
-
-  // Subscription UUIDs
-  const NimBLEUUID NOT1_CHR_UUID {0x00002008, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-  const NimBLEUUID NOT2_CHR_UUID {0x0000200a, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-
-  // Stage UUIDs
-  const NimBLEUUID PAIR_CHR_UUID {0x00002000, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-
-  const NimBLEUUID UNK1_CHR_UUID {0x00002009, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-  const NimBLEUUID UNK2_CHR_UUID {0x00002080, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-  const NimBLEUUID UNK3_CHR_UUID {0x00002086, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-  const NimBLEUUID UNK4_CHR_UUID {0x00002001, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-  const NimBLEUUID UNK5_CHR_UUID {0x00002082, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-  const NimBLEUUID UNK6_CHR_UUID {0x00002084, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-  const NimBLEUUID UNK7_CHR_UUID {0x00002001, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-
-  // Identifier UUIDs
-  const NimBLEUUID ID_CHR_UUID {0x00002002, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-
-  // Time and Location UUIDs
-  const NimBLEUUID TIME_CHR_UUID {0x00002006, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-  const NimBLEUUID GEO_CHR_UUID {0x00002007, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-
-  // Unknown UUIDs
-  const NimBLEUUID UNK0_CHR_UUID {0x00002009, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-
-  // Remote UUIDs
-  const NimBLEUUID REMOTE_R1_CHR_UUID {0x00002080, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-  const NimBLEUUID REMOTE_W1_CHR_UUID {0x00002082, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-  const NimBLEUUID REMOTE_SHUTTER_CHR_UUID {0x00002083, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-  const NimBLEUUID REMOTE_IND1_CHR_UUID {0x00002084, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-  const NimBLEUUID REMOTE_R2_CHR_UUID {0x00002086, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-  const NimBLEUUID REMOTE_PAIR_CHR_UUID {0x00002087, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
-
-  // Notification responses
-  static const std::array<uint8_t, 2> SUCCESS;
-  static const std::array<uint8_t, 2> GEO;  // ? Geo request?
-
-  // Task notification bits
-  static constexpr uint32_t NOTIFY_SUCCESS = (1 << 1);
-
-  // Control modes
-  static const uint8_t MODE_SHUTTER = 0x02;
-  static const uint8_t MODE_VIDEO = 0x03;
-  static const uint8_t MODE_MENU = 0x04;
-  static const uint8_t MODE_PLAYBACK = 0x05;
-
-  // Control commands
-  static const uint8_t CMD_PRESS = 0x02;
-  static const uint8_t CMD_RELEASE = 0x00;
-
   uint64_t m_Timestamp;
-  Pairing::id_t m_ID;
-  NimBLERemoteCharacteristic *m_PairChr = nullptr;
-  std::unique_ptr<Pairing> m_Pairing = nullptr;
-
+  NikonBase::Pairing::id_t m_ID;
   QueueHandle_t m_Queue;
-
-  /**
-   * Convert decimal degrees to degrees, minutes and sub-minute parts.
-   */
-  void degreesToDMSubMin(double value,
-                         uint8_t &degrees,
-                         uint8_t &minutes,
-                         uint8_t &submin1,
-                         uint8_t &submin2);
+  std::unique_ptr<NikonBase> m_Nikon = nullptr;
 
   /** Advertised device has requisite service UUID. */
   static bool matchesServiceUUID(const NimBLEAdvertisedDevice *pDevice);
 
-  /**
-   * Called during scanning for connection to saved device.
-   */
+  /** Called during scanning for connection to saved device. */
   void onResult(const NimBLEAdvertisedDevice *pDevice) override final;
 };
 

--- a/lib/furble/NikonBase.cpp
+++ b/lib/furble/NikonBase.cpp
@@ -1,0 +1,109 @@
+#include <cstring>
+
+#include <NimBLEDevice.h>
+#include <NimBLERemoteCharacteristic.h>
+#include <NimBLERemoteService.h>
+
+#include "NikonBase.h"
+
+namespace Furble {
+
+const NimBLEUUID NikonBase::SERVICE_UUID {0x0000de00, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+
+NikonBase::Pairing::Pairing(const uint64_t timestamp, const id_t id) {
+  m_Stage[0].stage = 0x01;
+  m_Stage[0].timestamp = timestamp;
+  m_Stage[0].id = id;
+  m_Stage[1].stage = 0x02;
+  m_Stage[2].stage = 0x03;
+  m_Stage[3].stage = 0x04;
+  m_Stage[4].stage = 0x05;
+
+  m_Msg = &m_Stage[0];
+}
+
+const NikonBase::Pairing::msg_t *NikonBase::Pairing::getMessage(void) const {
+  return m_Msg;
+}
+
+NikonBase::NikonBase(NimBLEClient *client,
+                     QueueHandle_t queue,
+                     NimBLERemoteCharacteristic *pairChr,
+                     std::atomic<uint8_t> *progress)
+    : m_Client(client), m_Queue(queue), m_PairChr(pairChr), m_Progress(progress) {}
+
+bool NikonBase::subscribePair(void) {
+  ESP_LOGI(LOG_TAG, "Subscribing to pairing indication");
+  if (!m_PairChr->subscribe(
+          false,
+          [this](NimBLERemoteCharacteristic *pBLERemoteCharacteristic, uint8_t *pData,
+                 size_t length, bool isNotify) {
+#if NIKON_DEBUG
+            ESP_LOGI(LOG_TAG, "data(stage) = %s",
+                     NimBLEUtils::dataToHexString(pData, length).c_str());
+#endif
+            NikonBase::Pairing::msg_t msg;
+            memcpy(&msg, pData, sizeof(msg));
+            auto pMsg = this->m_Pairing->processMessage(msg);
+            bool rc = (pMsg != nullptr);
+            if (!rc) {
+              ESP_LOGI(LOG_TAG, "Stage response mismatch");
+            }
+            xQueueSend(m_Queue, &rc, 0);
+          },
+          true)) {
+    return false;
+  }
+  ESP_LOGI(LOG_TAG, "Subscribed to pairing indication!");
+  return true;
+}
+
+bool NikonBase::handshake4Stage(void) {
+  bool success = true;
+  for (uint8_t stage = 0; stage < 4 && success; stage += 2) {
+    const auto *msg = m_Pairing->getMessage();
+    if (!m_PairChr->writeValue((const uint8_t *)msg, sizeof(*msg), true)) {
+      return false;
+    }
+#if NIKON_DEBUG
+    ESP_LOGI(LOG_TAG, "sent = %s",
+             NimBLEUtils::dataToHexString((const uint8_t *)msg, sizeof(*msg)).c_str());
+#endif
+
+    // wait 10s for a notification
+    BaseType_t timeout = xQueueReceive(m_Queue, &success, pdMS_TO_TICKS(10000));
+    if (timeout == pdFALSE) {
+      success = false;
+      ESP_LOGI(LOG_TAG, "Timeout waiting for stage %u response.", stage);
+      break;
+    }
+
+    *m_Progress += 5;
+  }
+  return success;
+}
+
+bool NikonBase::connect(NimBLERemoteService *pSvc) {
+  if (!preSubscribe(pSvc)) {
+    return false;
+  }
+  if (!subscribePair()) {
+    return false;
+  }
+
+  if (!handshake4Stage()) {
+    return false;
+  }
+
+  *m_Progress += 10;
+
+  if (!connectFinalise()) {
+    return false;
+  }
+
+  *m_Progress = 100;
+  ESP_LOGI(LOG_TAG, "Done!");
+  return true;
+}
+
+}  // namespace Furble

--- a/lib/furble/NikonBase.h
+++ b/lib/furble/NikonBase.h
@@ -1,0 +1,117 @@
+#ifndef NIKON_BASE_H
+#define NIKON_BASE_H
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+
+#include <NimBLEClient.h>
+#include <NimBLERemoteCharacteristic.h>
+#include <NimBLERemoteService.h>
+#include <NimBLEUUID.h>
+
+#include "Camera.h"
+
+#define NIKON_DEBUG (1)
+
+namespace Furble {
+
+/**
+ * Abstraction base shared by the Nikon Remote and Smart variants.
+ *
+ * NikonBase provides the middle layer logic handling allowing Remote and
+ * Smart protocol implementations to be self-contained.
+ */
+class NikonBase {
+ public:
+  /** Pairing protocol interface shared by both variants. */
+  class Pairing {
+   public:
+    /** Identifier. */
+    typedef struct __attribute__((packed)) _id_t {
+      uint32_t device;  // sent in manufacturer data in reconnect
+      uint32_t nonce;
+    } id_t;
+
+    /** Pairing message. */
+    typedef struct __attribute__((packed)) _msg_t {
+      uint8_t stage;
+      union {
+        struct __attribute__((packed)) {
+          uint32_t timestampH;
+          uint32_t timestampL;
+        };
+        uint64_t timestamp;
+      };
+      union {
+        id_t id;
+        char serial[8];
+      };
+    } msg_t;
+
+    virtual ~Pairing() = default;
+
+    virtual const msg_t *processMessage(const msg_t &msg) = 0;
+    const msg_t *getMessage(void) const;
+
+   protected:
+    Pairing(const uint64_t timestamp, const id_t id);
+
+    msg_t *m_Msg = nullptr;
+    std::array<msg_t, 5> m_Stage;
+
+   private:
+  };
+
+  virtual ~NikonBase() = default;
+
+  /**
+   * Connect to Nikon camera using the abstracted entry points.
+   *
+   * pre-subscribe, subscribe, 4-stage loop, then finalise.
+   *
+   * @return true iff connected successfully.
+   */
+  bool connect(NimBLERemoteService *pSvc);
+
+  virtual void shutterPress(void) = 0;
+  virtual void shutterRelease(void) = 0;
+  virtual void focusPress(void) = 0;
+  virtual void focusRelease(void) = 0;
+  virtual void updateGeoData(const Camera::gps_t &gps, const Camera::timesync_t &timesync) = 0;
+
+  /** Service UUID from advertisement data (shared). */
+  static const NimBLEUUID SERVICE_UUID;
+
+ protected:
+  NikonBase(NimBLEClient *client,
+            QueueHandle_t queue,
+            NimBLERemoteCharacteristic *pairChr,
+            std::atomic<uint8_t> *progress);
+
+  NimBLEClient *m_Client;
+  QueueHandle_t m_Queue;
+  NimBLERemoteCharacteristic *m_PairChr;
+  std::atomic<uint8_t> *m_Progress;
+  std::unique_ptr<Pairing> m_Pairing;
+
+  /** Pre-stage subscription (e.g. NOT1 / REMOTE_IND1). */
+  virtual bool preSubscribe(NimBLERemoteService *pSvc) = 0;
+
+  /** Post-stage finalisation. */
+  virtual bool connectFinalise(void) = 0;
+
+ private:
+  /** Subscribe to the pair characteristic's stage indications. */
+  bool subscribePair(void);
+
+  /** Drive the 4-stage handshake. */
+  bool handshake4Stage(void);
+};
+
+}  // namespace Furble
+#endif

--- a/lib/furble/NikonRemote.cpp
+++ b/lib/furble/NikonRemote.cpp
@@ -1,0 +1,112 @@
+#include <cstring>
+
+#include <NimBLEDevice.h>
+#include <NimBLERemoteCharacteristic.h>
+#include <NimBLERemoteService.h>
+
+#include "NikonRemote.h"
+
+namespace Furble {
+
+const NimBLEUUID NikonRemote::REMOTE_PAIR_CHR_UUID {0x00002087, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+
+NikonRemote::RemotePairing::RemotePairing(const uint64_t timestamp,
+                                          const NikonBase::Pairing::id_t &id)
+    : NikonBase::Pairing(timestamp, id) {
+  m_Stage[1].timestamp = 0x00;
+  m_Stage[1].id = {0x00, 0x00};
+  m_Stage[2].timestamp = 0x00;
+  m_Stage[2].id = {0x00, 0x00};
+  m_Stage[3].timestamp = 0x00;
+  m_Stage[3].id = {0x00, 0x00};
+  m_Stage[4].timestamp = 0x00;
+  m_Stage[4].id = {0x00, 0x00};
+}
+
+const NikonBase::Pairing::msg_t *NikonRemote::RemotePairing::processMessage(const msg_t &msg) {
+  switch (msg.stage) {
+    case 0:
+      m_Msg = &m_Stage[0];
+      return m_Msg;
+    case 2:
+    {
+      const msg_t *expected = &m_Stage[1];
+      if (memcmp(&msg, expected, sizeof(msg)) == 0) {
+        m_Msg = &m_Stage[2];
+        return m_Msg;
+      }
+    } break;
+    case 4:
+    {
+      if (msg.timestamp == m_Stage[3].timestamp) {
+        char serial[sizeof(msg.serial) + 1] = {0x00};
+        strncpy(serial, msg.serial, sizeof(serial) - 1);
+
+        ESP_LOGI(LOG_TAG, "Serial: %s", serial);
+        m_Msg = &m_Stage[4];
+        return m_Msg;
+      }
+    } break;
+  }
+
+  return nullptr;
+}
+
+NikonRemote::NikonRemote(NimBLEClient *client,
+                         QueueHandle_t queue,
+                         NimBLERemoteCharacteristic *pairChr,
+                         const NikonBase::Pairing::id_t &id,
+                         std::atomic<uint8_t> *progress)
+    : NikonBase(client, queue, pairChr, progress) {
+  m_Pairing = std::make_unique<RemotePairing>(__builtin_bswap64(0x01), id);
+}
+
+bool NikonRemote::preSubscribe(NimBLERemoteService *pSvc) {
+  ESP_LOGI(LOG_TAG, "Connecting as remote, subscribing to indication 1");
+  auto *pChr = pSvc->getCharacteristic(REMOTE_IND1_CHR_UUID);
+  if (!pChr->subscribe(
+          false,
+          [this](NimBLERemoteCharacteristic *pBLERemoteCharacteristic, uint8_t *pData,
+                 size_t length, bool isNotify) {
+#if NIKON_DEBUG
+            ESP_LOGI(LOG_TAG, "data(ind1) = %s",
+                     NimBLEUtils::dataToHexString(pData, length).c_str());
+#endif
+          },
+          true)) {
+    return false;
+  }
+  ESP_LOGI(LOG_TAG, "Subscribed to indication 1!");
+  return true;
+}
+
+bool NikonRemote::connectFinalise(void) {
+  // nothing more needed for remote mode
+  return true;
+}
+
+void NikonRemote::shutterPress(void) {
+  std::array<uint8_t, 2> cmd = {MODE_SHUTTER, CMD_PRESS};
+  m_Client->setValue(SERVICE_UUID, REMOTE_SHUTTER_CHR_UUID, {cmd.data(), cmd.size()}, true);
+}
+
+void NikonRemote::shutterRelease(void) {
+  std::array<uint8_t, 2> cmd = {MODE_SHUTTER, CMD_RELEASE};
+  m_Client->setValue(SERVICE_UUID, REMOTE_SHUTTER_CHR_UUID, {cmd.data(), cmd.size()}, true);
+}
+
+void NikonRemote::focusPress(void) {
+  // do nothing
+}
+
+void NikonRemote::focusRelease(void) {
+  // do nothing
+}
+
+void NikonRemote::updateGeoData(const Camera::gps_t &gps, const Camera::timesync_t &timesync) {
+  // Remote variant does not support geotagging.
+  (void)gps;
+  (void)timesync;
+}
+
+}  // namespace Furble

--- a/lib/furble/NikonRemote.h
+++ b/lib/furble/NikonRemote.h
@@ -1,0 +1,62 @@
+#ifndef NIKON_REMOTE_H
+#define NIKON_REMOTE_H
+
+#include <NimBLERemoteCharacteristic.h>
+#include <NimBLERemoteService.h>
+#include <NimBLEUUID.h>
+
+#include "NikonBase.h"
+
+namespace Furble {
+
+/**
+ * Nikon remote protocol (based on ML-L7).
+ */
+class NikonRemote: public NikonBase {
+ public:
+  NikonRemote(NimBLEClient *client,
+              QueueHandle_t queue,
+              NimBLERemoteCharacteristic *pairChr,
+              const NikonBase::Pairing::id_t &id,
+              std::atomic<uint8_t> *progress);
+
+  void shutterPress(void) override final;
+  void shutterRelease(void) override final;
+  void focusPress(void) override final;
+  void focusRelease(void) override final;
+  void updateGeoData(const Camera::gps_t &gps, const Camera::timesync_t &timesync) override final;
+
+  /** Pair characteristic UUID. */
+  static const NimBLEUUID REMOTE_PAIR_CHR_UUID;
+
+ private:
+  class RemotePairing: public NikonBase::Pairing {
+   public:
+    RemotePairing(const uint64_t timestamp, const NikonBase::Pairing::id_t &id);
+    const msg_t *processMessage(const msg_t &msg) override final;
+  };
+
+  // Remote characteristic UUIDs (instance).
+  const NimBLEUUID REMOTE_IND1_CHR_UUID {0x00002084, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID REMOTE_SHUTTER_CHR_UUID {0x00002083, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  // Carried forward (currently unused).
+  const NimBLEUUID REMOTE_R1_CHR_UUID {0x00002080, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID REMOTE_W1_CHR_UUID {0x00002082, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID REMOTE_R2_CHR_UUID {0x00002086, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+
+  // Control modes.
+  static constexpr uint8_t MODE_SHUTTER = 0x02;
+  static constexpr uint8_t MODE_VIDEO = 0x03;
+  static constexpr uint8_t MODE_MENU = 0x04;
+  static constexpr uint8_t MODE_PLAYBACK = 0x05;
+
+  // Control commands.
+  static constexpr uint8_t CMD_PRESS = 0x02;
+  static constexpr uint8_t CMD_RELEASE = 0x00;
+
+  bool preSubscribe(NimBLERemoteService *pSvc) override final;
+  bool connectFinalise(void) override final;
+};
+
+}  // namespace Furble
+#endif

--- a/lib/furble/NikonSmart.cpp
+++ b/lib/furble/NikonSmart.cpp
@@ -1,0 +1,281 @@
+#include <cmath>
+#include <cstring>
+
+#include <NimBLEDevice.h>
+#include <NimBLERemoteCharacteristic.h>
+#include <NimBLERemoteService.h>
+
+#include "Device.h"
+#include "NikonSmart.h"
+
+namespace Furble {
+
+const std::vector<uint8_t> NikonSmart::SmartPairing::KEY = {0xff, 0xff, 0xaa, 0x55,
+                                                            0x11, 0x22, 0x33, 0x00};
+const std::array<std::array<uint32_t, 2>, 8> NikonSmart::SmartPairing::SALT = {
+    {
+     {0x704066e4u, 0x0433d552u},
+     {0xed4b8facu, 0x15f7e47bu},
+     {0x24471f11u, 0x8b5ea1fcu},
+     {0x05960c31u, 0x2b8c7f41u},
+     {0xfda588c1u, 0xeba8b1f3u},
+     {0x99166056u, 0x1bd3d550u},
+     {0xcd32687fu, 0xa9e28a30u},
+     {0x2a8fe834u, 0xdec7ebf4u},
+
+     }
+};
+const NimBLEUUID NikonSmart::PAIR_CHR_UUID {0x00002000, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+constexpr std::array<uint8_t, 2> NikonSmart::SUCCESS;
+
+NikonSmart::SmartPairing::SmartPairing(const uint64_t timestamp, const NikonBase::Pairing::id_t id)
+    : NikonBase::Pairing(timestamp, id), Blowfish(KEY) {
+  m_Stage[2].timestamp = timestamp;
+}
+
+void NikonSmart::SmartPairing::scramble(uint32_t *pL, uint32_t *pR) const {
+  uint32_t xL = *pL;
+  uint32_t xR = *pR;
+  uint32_t tmp = 0;
+
+  for (int i = 0; i < N; i++) {
+    tmp = xL ^ m_P[i];
+    xL = f(tmp) ^ xR;
+    xR = tmp;
+  }
+
+  *pL = tmp ^ m_P[N + 1];
+  *pR = xL ^ m_P[N];
+}
+
+std::array<uint32_t, 2> NikonSmart::SmartPairing::hash(const uint32_t *src, size_t len) const {
+  uint32_t right = 0x05060708;
+  uint32_t left = 0x01020304;
+  uint32_t inL = 0;
+  uint32_t inR = 0;
+
+  for (uint16_t i = 0; i < len; i += 2) {
+    inL = src[i] ^ left;
+    inR = src[i + 1] ^ right;
+    scramble(&inL, &inR);
+    left = inL;
+    right = inR;
+  }
+
+  return std::array<uint32_t, 2> {inL, inR};
+}
+
+int8_t NikonSmart::SmartPairing::findSaltIndex(const msg_t &msg) {
+  for (size_t i = 0; i < SALT.size(); i++) {
+    std::array<uint32_t, 6> s = {SALT[i][0],
+                                 SALT[i][1],
+                                 __builtin_bswap32(msg.timestampH),
+                                 __builtin_bswap32(msg.timestampL),
+                                 __builtin_bswap32(m_Stage[0].timestampH),
+                                 __builtin_bswap32(m_Stage[0].timestampL)};
+    std::array<uint32_t, 2> s2 = hash(s.data(), s.size());
+    if ((s2[0] == __builtin_bswap32(msg.id.device) && (s2[1] == __builtin_bswap32(msg.id.nonce)))) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+const NikonBase::Pairing::msg_t *NikonSmart::SmartPairing::processMessage(const msg_t &msg) {
+  switch (msg.stage) {
+    case 0:
+      m_Msg = &m_Stage[0];
+      return m_Msg;
+    case 2:
+    {
+      m_Salt = findSaltIndex(msg);
+      if (m_Salt >= 0) {
+        std::array<uint32_t, 6> buffer = {SALT[m_Salt][0],
+                                          SALT[m_Salt][1],
+                                          __builtin_bswap32(m_Stage[0].timestampH),
+                                          __builtin_bswap32(m_Stage[0].timestampL),
+                                          __builtin_bswap32(msg.timestampH),
+                                          __builtin_bswap32(msg.timestampL)};
+        std::array<uint32_t, 2> s3 = hash(buffer.data(), buffer.size());
+        m_Stage[2].id = {__builtin_bswap32(s3[0]), __builtin_bswap32(s3[1])};
+        m_Msg = &m_Stage[2];
+
+        m_Stage[3].timestamp = msg.timestamp;
+
+        return m_Msg;
+      }
+    } break;
+    case 4:
+    {
+      if (msg.timestamp == m_Stage[3].timestamp) {
+        char serial[sizeof(msg.serial) + 1] = {0x00};
+        strncpy(serial, msg.serial, sizeof(serial) - 1);
+
+        ESP_LOGI(LOG_TAG, "Serial: %s", serial);
+        m_Msg = &m_Stage[4];
+        return m_Msg;
+      }
+    } break;
+  }
+
+  return nullptr;
+}
+
+NikonSmart::NikonSmart(NimBLEClient *client,
+                       QueueHandle_t queue,
+                       NimBLERemoteCharacteristic *pairChr,
+                       const NikonBase::Pairing::id_t &id,
+                       const uint64_t timestamp,
+                       std::atomic<uint8_t> *progress)
+    : NikonBase(client, queue, pairChr, progress) {
+  m_Pairing = std::make_unique<SmartPairing>(timestamp, id);
+}
+
+bool NikonSmart::preSubscribe(NimBLERemoteService *pSvc) {
+  ESP_LOGI(LOG_TAG, "Connecting as smart device, subscribing to success notification");
+  auto *pChr = pSvc->getCharacteristic(NOT1_CHR_UUID);
+  if (!pChr->subscribe(
+          true,
+          [this](NimBLERemoteCharacteristic *pBLERemoteCharacteristic, uint8_t *pData,
+                 size_t length, bool isNotify) {
+            bool rc = false;
+#if NIKON_DEBUG
+            ESP_LOGI(LOG_TAG, "data(not1) = %s",
+                     NimBLEUtils::dataToHexString(pData, length).c_str());
+#endif
+            if (memcmp(pData, SUCCESS.data(), length) == 0) {
+              rc = true;
+            }
+            xQueueSend(m_Queue, &rc, 0);
+          },
+          true)) {
+    return false;
+  }
+  ESP_LOGI(LOG_TAG, "Subscribed to success notification!");
+  return true;
+}
+
+bool NikonSmart::connectFinalise(void) {
+  bool success = false;
+  // wait for final OK
+  BaseType_t timeout = xQueueReceive(m_Queue, &success, pdMS_TO_TICKS(10000));
+  if (timeout == pdFALSE) {
+    success = false;
+    ESP_LOGI(LOG_TAG, "Timeout waiting for final OK.");
+  }
+
+  if (!success) {
+    return false;
+  }
+
+  const auto name = Device::getStringID();
+  ESP_LOGI(LOG_TAG, "Identifying as %s", name.c_str());
+  if (!m_Client->setValue(SERVICE_UUID, ID_CHR_UUID, name, true)) {
+    return false;
+  }
+
+  // Unable to continue at this time
+  // For some reason Nikon smart device pairing swaps to Bluetooth Classic to
+  // establish secure bond and our Bluetooth stack is LE only.
+  ESP_LOGI(LOG_TAG, "Nikon smart device pairing not fully functional");
+
+  return false;
+}
+
+void NikonSmart::shutterPress(void) {
+  // do nothing
+}
+
+void NikonSmart::shutterRelease(void) {
+  // do nothing
+}
+
+void NikonSmart::focusPress(void) {
+  // do nothing
+}
+
+void NikonSmart::focusRelease(void) {
+  // do nothing
+}
+
+void NikonSmart::updateGeoData(const Camera::gps_t &gps, const Camera::timesync_t &timesync) {
+  nikon_time_t ntime = {
+      .year = (uint16_t)timesync.year,
+      .month = (uint8_t)timesync.month,
+      .day = (uint8_t)timesync.day,
+      .hour = (uint8_t)timesync.hour,
+      .minute = (uint8_t)timesync.minute,
+      .second = (uint8_t)timesync.second,
+  };
+
+  nikon_geo_t geo = {
+      .header = 0x007f,
+      .latitude_direction = gps.latitude < 0.0 ? 'S' : 'N',
+      .latitude_degrees = 0,
+      .latitude_minutes = 0,
+      .latitude_submin1 = 0,
+      .latitude_submin2 = 0,
+      .longitude_direction = gps.longitude < 0.0 ? 'W' : 'E',
+      .longitude_degrees = 0,
+      .longitude_minutes = 0,
+      .longitude_submin1 = 0,
+      .longitude_submin2 = 0,
+      .satellites = static_cast<uint8_t>(gps.satellites),
+      .altitude_ref = gps.altitude < 0.0 ? 'M' : 'P',
+      .altitude = (uint16_t)gps.altitude,
+      .time = ntime,
+      .subseconds = (uint8_t)timesync.centisecond,
+      .valid = 0x01,
+      .standard = {'W', 'G', 'S', '-', '8', '4'},
+      .pad = {0x00},
+  };
+
+  degreesToDMSubMin(gps.latitude, geo.latitude_degrees, geo.latitude_minutes, geo.latitude_submin1,
+                    geo.latitude_submin2);
+  degreesToDMSubMin(gps.longitude, geo.longitude_degrees, geo.longitude_minutes,
+                    geo.longitude_submin1, geo.longitude_submin2);
+
+  ESP_LOGI(LOG_TAG, "sending GPS = %s",
+           NimBLEUtils::dataToHexString((const uint8_t *)&geo, sizeof(geo)).c_str());
+  if (m_Client->setValue(SERVICE_UUID, GEO_CHR_UUID, {(const uint8_t *)&geo, (uint16_t)sizeof(geo)},
+                         true)) {
+    ESP_LOGI(LOG_TAG, "  success");
+  } else {
+    ESP_LOGI(LOG_TAG, "  failed");
+  }
+}
+
+// Converts a decimal-degree value into the Nikon encoding:
+// degrees, whole minutes, and two "sub-minute" bytes that
+// together represent the fractional minutes as a 4-digit number
+// (submin1 = hundredths of a minute, submin2 = hundredths of the
+// remainder).
+void NikonSmart::degreesToDMSubMin(double value,
+                                   uint8_t &degrees,
+                                   uint8_t &minutes,
+                                   uint8_t &submin1,
+                                   uint8_t &submin2) {
+  double integral;
+  double absValue = std::fabs(value);
+
+  // Whole degrees (truncated, matching Math.floor on a non-negative value).
+  std::modf(absValue, &integral);
+  degrees = (uint8_t)integral;
+
+  // Remaining fractional degrees, converted to minutes.
+  double minutesFull = (absValue - degrees) * 60.0;
+  std::modf(minutesFull, &integral);
+  minutes = (uint8_t)integral;
+
+  // Remaining fractional minutes, scaled by 100
+  double subMinFull = (minutesFull - minutes) * 100.0;
+  std::modf(subMinFull, &integral);
+  submin1 = (uint8_t)integral;
+
+  // Remaining fractional hundredths-of-a-minute, scaled by 100 again.
+  double subMin2Full = (subMinFull - submin1) * 100.0;
+  std::modf(subMin2Full, &integral);
+  submin2 = (uint8_t)integral;
+}
+
+}  // namespace Furble

--- a/lib/furble/NikonSmart.h
+++ b/lib/furble/NikonSmart.h
@@ -1,0 +1,133 @@
+#ifndef NIKON_SMART_H
+#define NIKON_SMART_H
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include <NimBLERemoteCharacteristic.h>
+#include <NimBLERemoteService.h>
+#include <NimBLEUUID.h>
+
+#include "Blowfish.h"
+#include "Camera.h"
+#include "NikonBase.h"
+
+namespace Furble {
+
+/**
+ * Nikon smart-device (Blowfish-crypted handshake).
+ *
+ * Currently non-functional due to requirement on Bluetooth Classic to exchange
+ * secrets.
+ */
+class NikonSmart: public NikonBase {
+ public:
+  NikonSmart(NimBLEClient *client,
+             QueueHandle_t queue,
+             NimBLERemoteCharacteristic *pairChr,
+             const NikonBase::Pairing::id_t &id,
+             const uint64_t timestamp,
+             std::atomic<uint8_t> *progress);
+
+  void shutterPress(void) override final;
+  void shutterRelease(void) override final;
+  void focusPress(void) override final;
+  void focusRelease(void) override final;
+  void updateGeoData(const Camera::gps_t &gps, const Camera::timesync_t &timesync) override final;
+
+  /** Pair characteristic UUID. */
+  static const NimBLEUUID PAIR_CHR_UUID;
+
+ private:
+  class SmartPairing: public NikonBase::Pairing, private Blowfish {
+   public:
+    SmartPairing(const uint64_t timestamp, const NikonBase::Pairing::id_t id);
+    const msg_t *processMessage(const msg_t &msg) override final;
+    std::array<uint32_t, 2> hash(const uint32_t *src, size_t len) const;
+
+   private:
+    void scramble(uint32_t *pL, uint32_t *pR) const;
+    int8_t findSaltIndex(const msg_t &msg);
+
+    static const std::vector<uint8_t> KEY;
+    static const std::array<std::array<uint32_t, 2>, 8> SALT;
+    int8_t m_Salt = -1;
+  };
+
+  // Smart characteristic UUIDs (instance).
+  const NimBLEUUID NOT1_CHR_UUID {0x00002008, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID ID_CHR_UUID {0x00002002, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID GEO_CHR_UUID {0x00002007, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  // Carried forward (currently unused).
+  const NimBLEUUID NOT2_CHR_UUID {0x0000200a, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID TIME_CHR_UUID {0x00002006, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID UNK0_CHR_UUID {0x00002009, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID UNK1_CHR_UUID {0x00002009, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID UNK2_CHR_UUID {0x00002080, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID UNK3_CHR_UUID {0x00002086, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID UNK4_CHR_UUID {0x00002001, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID UNK5_CHR_UUID {0x00002082, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID UNK6_CHR_UUID {0x00002084, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+  const NimBLEUUID UNK7_CHR_UUID {0x00002001, 0x3dd4, 0x4255, 0x8d626dc7b9bd5561};
+
+  // Notification responses.
+  static constexpr std::array<uint8_t, 2> SUCCESS = {0x01, 0x00};
+  // Carried forward (currently unused).
+  static constexpr std::array<uint8_t, 2> GEO = {0x00, 0x01};
+
+  /** Time synchronisation. */
+  typedef struct __attribute__((packed)) _nikon_time_t {
+    uint16_t year;
+    uint8_t month;
+    uint8_t day;
+    uint8_t hour;
+    uint8_t minute;
+    uint8_t second;
+  } nikon_time_t;
+
+  // 10 bytes (carried forward; currently unused).
+  typedef struct __attribute__((packed)) _timesync_msg_t {
+    nikon_time_t time;
+    uint8_t dst_offset;
+    uint8_t tz_offset_hours;
+    uint8_t tz_offset_minutes;
+  } timesync_msg_t;
+
+  // 41 bytes
+  /** Location synchronisation. */
+  typedef struct __attribute__((packed)) _nikon_geo_t {
+    uint16_t header;             // 0x7f00 = isLat | isLon | isSat | isAlt |
+                                 // isPos | isGps | isMap
+    uint8_t latitude_direction;  // {N|S}
+    uint8_t latitude_degrees;
+    uint8_t latitude_minutes;
+    uint8_t latitude_submin1;     // Remaining fractional minutes(hundredths of a minute)
+    uint8_t latitude_submin2;     // Remaining fractional hundredths-of-a-minute
+    uint8_t longitude_direction;  // {E|W}
+    uint8_t longitude_degrees;
+    uint8_t longitude_minutes;
+    uint8_t longitude_submin1;  // Remaining fractional minutes(hundredths of a minute)
+    uint8_t longitude_submin2;  // Remaining fractional hundredths-of-a-minute
+    uint8_t satellites;         // no. of satellites
+    uint8_t altitude_ref;       // P=0x50 for positive, M=0x4D for negative altitude
+    uint16_t altitude;
+    nikon_time_t time;
+    uint8_t subseconds;
+    uint8_t valid;        // 0x01 == valid
+    uint8_t standard[6];  // WGS-84
+    uint8_t pad[10];
+  } nikon_geo_t;
+
+  bool preSubscribe(NimBLERemoteService *pSvc) override final;
+  bool connectFinalise(void) override final;
+
+  void degreesToDMSubMin(double value,
+                         uint8_t &degrees,
+                         uint8_t &minutes,
+                         uint8_t &submin1,
+                         uint8_t &submin2);
+};
+
+}  // namespace Furble
+#endif


### PR DESCRIPTION
Split the monolithic Nikon protocol into the 2 known instances: remote and smart.
This keeps the protocols self-contained and simpler to maintain going forward.
Nikon appears to retain the higher level handshake, so NikonBase drives that and delegates to the specialisation when needed.