### PR TITLE
Remove BLE advertising.

### DIFF
--- a/lib/furble/Scan.cpp
+++ b/lib/furble/Scan.cpp
@@ -1,4 +1,3 @@
-#include <NimBLEAdvertisedDevice.h>
 #include <NimBLEScan.h>
 
 #include "Device.h"
@@ -14,10 +13,6 @@ Scan &Scan::getInstance(void) {
 
   if (instance.m_Scan == nullptr) {
     instance.m_Server = NimBLEDevice::createServer();
-    instance.m_Advertising = instance.m_Server->getAdvertising();
-    instance.m_Advertising->setName(FURBLE_STR);
-    instance.m_Advertising->setAppearance(HID_GENERIC_REMOTE);
-    instance.m_Advertising->enableScanResponse(true);
 
     instance.m_Scan = NimBLEDevice::getScan();
     instance.m_Scan->setActiveScan(true);
@@ -41,7 +36,7 @@ void Scan::onResult(const NimBLEAdvertisedDevice *pDevice) {
 };
 
 void Scan::start(std::function<void(void *)> scanCallback, void *scanPrivateData) {
-  m_Advertising->start(0, nullptr);
+  m_Server->start();
   m_Scan->setScanCallbacks(this);
 
   m_ScanResultCallback = scanCallback;
@@ -55,7 +50,6 @@ void Scan::start(NimBLEScanCallbacks *pScanCallbacks, uint32_t duration) {
 }
 
 void Scan::stop(void) {
-  m_Advertising->stop();
   m_Scan->stop();
   m_ScanResultPrivateData = nullptr;
   m_ScanResultCallback = nullptr;

--- a/lib/furble/Scan.h
+++ b/lib/furble/Scan.h
@@ -61,7 +61,6 @@ class Scan: public NimBLEScanCallbacks {
   static constexpr uint16_t HID_GENERIC_REMOTE = 0x180;
 
   NimBLEServer *m_Server = nullptr;
-  NimBLEAdvertising *m_Advertising = nullptr;
   NimBLEScan *m_Scan = nullptr;
   std::function<void(void *)> m_ScanResultCallback;
   void *m_ScanResultPrivateData = nullptr;


### PR DESCRIPTION
Advertising was left enabled to allow Sony cameras to continue connecting.
Investigation shows this is strictly not necessary. During connection, Sony cameras make a single request to obtain the client device name, this requires only the server to be active.