### PR TITLE
Add CPU frequency setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ Some camera protocols such as Ricoh GR trigger capture with a single operation r
 
 When in `Shutter` remote control, holding focus (button B) then release (button A) will engage shutter lock, holding the shutter open until a button is pressed.
 
+### Power
+
+The CPU speed can be selected under `Settings->Power->CPU speed`, with a choice
+of 80, 160 or 240 MHz.
+The default is 160 MHz, and a change takes effect immediately.
+
+A higher speed makes the interface feel snappier, but it costs battery life.
+80 MHz is the gentlest on the battery, 240 MHz is the most demanding.
+
 ### Themes
 
 A few basic themes are included, to change:

--- a/include/FurblePlatform.h
+++ b/include/FurblePlatform.h
@@ -1,11 +1,21 @@
 #ifndef FURBLE_PLATFORM_H
 #define FURBLE_PLATFORM_H
 
+#include <array>
+
+#include <esp_err.h>
+
 #include <M5PM1.h>
 
 namespace Furble {
 class Platform {
  public:
+  /** Selectable maximum CPU frequencies in MHz. */
+  static constexpr std::array<uint8_t, 3> CPU_MAX_FREQ_MHZ = {80, 160, 240};
+
+  /** Default maximum CPU frequency in MHz. */
+  static constexpr uint8_t CPU_MAX_FREQ_DEFAULT_MHZ = 160;
+
   static Platform &getInstance();
 
   Platform(Platform const &) = delete;
@@ -40,10 +50,32 @@ class Platform {
    */
   void setSleep(bool enable);
 
+  /**
+   * Set the maximum CPU frequency in MHz.
+   *
+   * Unsupported values fall back to the default. Use getCPUMaxFreq() to read
+   * back what was actually applied.
+   */
+  void setCPUMaxFreq(uint8_t mhz);
+
+  /**
+   * Get the maximum CPU frequency in MHz.
+   */
+  uint8_t getCPUMaxFreq(void) const;
+
  private:
   Platform() {};
 
-  const int CPU_MAX_FREQ_MHZ = 160;
+  /**
+   * Apply the power management configuration.
+   */
+  esp_err_t configurePM(uint8_t max_freq_mhz, bool sleep);
+
+  /**
+   * Is the frequency one we are prepared to ask for?
+   */
+  static bool isCPUMaxFreqValid(uint8_t mhz);
+
   const int CPU_MIN_FREQ_MHZ = 40;
 
   // Power button click streak threshold
@@ -53,6 +85,8 @@ class Platform {
 
   bool m_Init = false;
   bool m_PMICHack = false;
+  bool m_Sleep = true;
+  uint8_t m_CPUMaxFreqMHz = CPU_MAX_FREQ_DEFAULT_MHZ;
   uint8_t m_PMICClickCount = 0;
   uint32_t m_PMICClickTime = 0;
 };

--- a/include/FurbleSettings.h
+++ b/include/FurbleSettings.h
@@ -26,6 +26,7 @@ class Settings {
     FAUXNY,
     TOUCH_CALIBRATION,
     AUTOCONNECT,
+    CPU_FREQ,
   } type_t;
 
   typedef struct {
@@ -61,6 +62,9 @@ class Settings {
 
   static constexpr uint32_t BAUD_9600 = 9600;
   static constexpr uint32_t BAUD_115200 = 115200;
+
+  /** Default maximum CPU frequency in MHz, matches Platform. */
+  static constexpr uint8_t CPU_FREQ_DEFAULT = 160;
 
   static void init(void);
 
@@ -145,6 +149,10 @@ struct Settings::storage_type<Settings::TOUCH_CALIBRATION> {
 template <>
 struct Settings::storage_type<Settings::AUTOCONNECT> {
   using type = bool;
+};
+template <>
+struct Settings::storage_type<Settings::CPU_FREQ> {
+  using type = uint8_t;
 };
 
 }  // namespace Furble

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -180,6 +180,7 @@ class UI {
   static constexpr const char *m_ThemeStr = "Theme";
   static constexpr const char *m_TransmitPowerStr = "TX Power";
   static constexpr const char *m_AboutStr = "About";
+  static constexpr const char *m_PowerStr = "Power";
 
   // settings->gps
   static constexpr const char *m_GPSDataStr = "GPS Data";
@@ -335,6 +336,9 @@ class UI {
   void addSpinnerPage(const menu_t &parent, const char *item, Intervalometer::Spinner &spinner);
 
   void addDisplayMenu(const menu_t &parent);
+
+  /** Add the 'Power' menu entry. */
+  void addPowerMenu(const menu_t &parent);
 
   void addThemeMenu(const menu_t &parent);
 

--- a/src/FurblePlatform.cpp
+++ b/src/FurblePlatform.cpp
@@ -1,9 +1,12 @@
+#include <algorithm>
+
 #include <esp_pm.h>
 
 #include <M5PM1.h>
 #include <M5Unified.h>
 
 #include "FurblePlatform.h"
+#include "FurbleTypes.h"
 
 namespace Furble {
 
@@ -62,13 +65,48 @@ uint8_t Platform::getPWRClickCount(void) {
   return count;
 }
 
-void Platform::setSleep(bool enable) {
+esp_err_t Platform::configurePM(uint8_t max_freq_mhz, bool sleep) {
   esp_pm_config_t pm_config = {
-      .max_freq_mhz = CPU_MAX_FREQ_MHZ,
+      .max_freq_mhz = max_freq_mhz,
       .min_freq_mhz = CPU_MIN_FREQ_MHZ,
-      .light_sleep_enable = enable,
+      .light_sleep_enable = sleep,
   };
-  ESP_ERROR_CHECK(esp_pm_configure(&pm_config));
+  return esp_pm_configure(&pm_config);
+}
+
+bool Platform::isCPUMaxFreqValid(uint8_t mhz) {
+  return std::find(CPU_MAX_FREQ_MHZ.begin(), CPU_MAX_FREQ_MHZ.end(), mhz) != CPU_MAX_FREQ_MHZ.end();
+}
+
+void Platform::setSleep(bool enable) {
+  m_Sleep = enable;
+  ESP_ERROR_CHECK(configurePM(m_CPUMaxFreqMHz, enable));
+}
+
+void Platform::setCPUMaxFreq(uint8_t mhz) {
+  uint8_t freq = mhz;
+
+  // NVS may hold anything, never hand an unvetted value to esp_pm_configure()
+  if (!isCPUMaxFreqValid(freq)) {
+    ESP_LOGW(LOG_TAG, "Unsupported CPU maximum frequency %dMHz, using %dMHz.", freq,
+             CPU_MAX_FREQ_DEFAULT_MHZ);
+    freq = CPU_MAX_FREQ_DEFAULT_MHZ;
+  }
+
+  // The board may still refuse the frequency, fall back rather than abort
+  esp_err_t err = configurePM(freq, m_Sleep);
+  if (err != ESP_OK) {
+    ESP_LOGW(LOG_TAG, "CPU maximum frequency %dMHz rejected (%s), using %dMHz.", freq,
+             esp_err_to_name(err), CPU_MAX_FREQ_DEFAULT_MHZ);
+    freq = CPU_MAX_FREQ_DEFAULT_MHZ;
+    ESP_ERROR_CHECK(configurePM(freq, m_Sleep));
+  }
+
+  m_CPUMaxFreqMHz = freq;
+}
+
+uint8_t Platform::getCPUMaxFreq(void) const {
+  return m_CPUMaxFreqMHz;
 }
 
 void Platform::powerOff(void) {

--- a/src/FurblePlatform.cpp
+++ b/src/FurblePlatform.cpp
@@ -103,6 +103,8 @@ void Platform::setCPUMaxFreq(uint8_t mhz) {
   }
 
   m_CPUMaxFreqMHz = freq;
+
+  ESP_LOGI(LOG_TAG, "CPU maximum frequency %dMHz.", m_CPUMaxFreqMHz);
 }
 
 uint8_t Platform::getCPUMaxFreq(void) const {

--- a/src/FurbleSettings.cpp
+++ b/src/FurbleSettings.cpp
@@ -21,6 +21,7 @@ const std::unordered_map<Settings::type_t, Settings::setting_t> Settings::m_Sett
     {FAUXNY,            {FAUXNY, "FauxNY", "fauxNY", FURBLE_STR}                       },
     {TOUCH_CALIBRATION, {TOUCH_CALIBRATION, "Touch Calibration", "t_calib", FURBLE_STR}},
     {AUTOCONNECT,       {AUTOCONNECT, "Auto-Connect", "autoconnect", FURBLE_STR}       },
+    {CPU_FREQ,          {CPU_FREQ, "CPU Speed", "cpu_freq", FURBLE_STR}                },
 };
 
 const Settings::setting_t &Settings::get(type_t type) {
@@ -215,6 +216,9 @@ void Settings::init(void) {
           break;
         case GPS_BAUD:
           save<uint32_t>(setting.type, BAUD_9600);
+          break;
+        case CPU_FREQ:
+          save<uint8_t>(setting.type, CPU_FREQ_DEFAULT);
           break;
         case TOUCH_CALIBRATION:
         {

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -69,6 +69,7 @@ std::unordered_map<const char *, UI::menu_t> UI::m_Menu = {
     {m_ThemeStr,             {nullptr, nullptr, nullptr, nullptr, {0, 1}}},
     {m_TransmitPowerStr,     {nullptr, nullptr, nullptr, nullptr, {1, 1}}},
     {m_AboutStr,             {nullptr, nullptr, nullptr, nullptr, {2, 1}}},
+    {m_PowerStr,             {nullptr, nullptr, nullptr, nullptr, {3, 1}}},
     {m_RemoteShutter,        {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_RemoteInterval,       {nullptr, nullptr, nullptr, nullptr, {1, 0}}},
     {m_RemoteDisconnect,     {nullptr, nullptr, nullptr, nullptr, {2, 0}}},
@@ -1949,6 +1950,61 @@ void UI::addDisplayMenu(const menu_t &parent) {
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }
 
+void UI::addPowerMenu(const menu_t &parent) {
+  menu_t &menu = addMenu(m_PowerStr, &icon_power_settings_new, true, parent);
+  lv_obj_t *cont = lv_menu_cont_create(menu.page);
+  lv_obj_set_height(cont, LV_PCT(100));
+  lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+
+  // Add CPU maximum frequency control
+  lv_obj_t *label = lv_label_create(cont);
+  lv_label_set_text(label, "CPU speed");
+  lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+  lv_obj_set_width(label, LV_PCT(100));
+
+  const auto &frequencies = Platform::CPU_MAX_FREQ_MHZ;
+  std::string options;
+  for (const auto mhz : frequencies) {
+    if (!options.empty()) {
+      options += "\n";
+    }
+    options += std::to_string(mhz) + " MHz";
+  }
+
+  lv_obj_t *roller = lv_roller_create(cont);
+  lv_obj_set_width(roller, LV_PCT(90));
+  lv_roller_set_options(roller, options.c_str(), LV_ROLLER_MODE_INFINITE);
+  lv_roller_set_visible_row_count(roller, 2);
+
+  // The roller index is not the frequency, map it explicitly
+  // getCPUMaxFreq() only ever returns a listed frequency, so the find succeeds
+  auto &platform = Platform::getInstance();
+  uint32_t index =
+      std::distance(frequencies.begin(),
+                    std::find(frequencies.begin(), frequencies.end(), platform.getCPUMaxFreq()));
+  lv_roller_set_selected(roller, index, LV_ANIM_OFF);
+
+  lv_obj_add_event_cb(
+      roller,
+      [](lv_event_t *e) {
+        auto *roller = static_cast<lv_obj_t *>(lv_event_get_target(e));
+        auto index = lv_roller_get_selected(roller);
+        if (index >= Platform::CPU_MAX_FREQ_MHZ.size()) {
+          return;
+        }
+
+        // Takes effect immediately, save what was actually applied
+        auto &platform = Platform::getInstance();
+        platform.setCPUMaxFreq(Platform::CPU_MAX_FREQ_MHZ[index]);
+        Settings::save<Settings::CPU_FREQ>(platform.getCPUMaxFreq());
+      },
+      LV_EVENT_VALUE_CHANGED, NULL);
+
+  lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
+}
+
 void UI::addThemeMenu(const menu_t &parent) {
   menu_t &menu = addMenu(m_ThemeStr, &icon_palette, true, parent);
 
@@ -2077,6 +2133,7 @@ void UI::addSettingsMenu(void) {
   addThemeMenu(menu);
   addTransmitPowerMenu(menu);
   addAboutMenu(menu);
+  addPowerMenu(menu);
 
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,11 @@ void app_main() {
 
   Furble::Platform::init();
   Furble::Settings::init();
+
+  // Platform::init() runs before NVS exists, apply the stored frequency now
+  Furble::Platform::getInstance().setCPUMaxFreq(
+      Furble::Settings::load<Furble::Settings::CPU_FREQ>());
+
   Furble::Device::init(Furble::Settings::load<esp_power_level_t>(Furble::Settings::TX_POWER));
 
   auto &control = Furble::Control::getInstance();


### PR DESCRIPTION
Motivation: I am chasing battery life on the M5StickS3 and found the firmware asks esp_pm for a 160 MHz maximum while the build configures an 80 MHz boot clock. I wanted the mismatch resolved deliberately and the trade-off between speed and battery to be mine to make on the device.

The esp_pm maximum frequency was hardcoded to 160 MHz while the build and sdkconfig boot the CPU at 80 MHz. This makes the maximum a runtime setting under a new Settings -> Power page, with values of 80, 160 and 240 MHz. The default is 160, which is exactly what the code did before, so existing devices see no change. Values loaded from NVS are validated before they reach esp_pm_configure, and a frequency the board rejects falls back to 160 MHz instead of aborting the boot.

Verified by build on all five environments and flashed to a M5StickS3: boots clean, the stored default applies without warnings. 240 MHz still needs an on-device roller check. No camera vendor code is touched.

Plan document: https://github.com/MaxRink/furble/blob/plans/plans/01-cpu-freq-setting.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)