### PR TITLE
Add USB debug build environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,41 @@ In most cases it should be:
 
 More details are on the wiki: [PlatformIO](https://github.com/gkoh/furble/wiki/Linux-Command-Line-(For-Developers))
 
+### Debug builds (developers)
+
+Every board has an optional `<board>-debug` environment, for example
+`m5stick-s3-debug`. These are built with `build_type = debug` and with
+`LOG_LOCAL_LEVEL=ESP_LOG_VERBOSE`, so `ESP_LOGD` and `ESP_LOGV` in furble
+sources are compiled in. They share the release `sdkconfig` of the board they
+extend, so nothing but the compiler flags changes. CI and releases build the
+five release environments only, never the debug ones.
+
+Build, flash and watch the log:
+- `platformio run -e m5stick-s3-debug -t upload`
+- `platformio device monitor -e m5stick-s3-debug`
+
+The runtime log level still starts at `INFO` because `CONFIG_LOG_DEFAULT_LEVEL`
+is `3` in the committed `sdkconfig` files. Call
+`esp_log_level_set("*", ESP_LOG_VERBOSE)` to lift it. The ceiling
+`CONFIG_LOG_MAXIMUM_LEVEL` is already `5`, so no `sdkconfig` change is needed.
+
+The M5StickS3 is an ESP32-S3, which has a built-in USB-Serial/JTAG peripheral on
+GPIO19 and GPIO20. Its debug environment selects `debug_tool = esp-builtin`, so
+source level debugging over the USB-C port needs no extra hardware:
+- `platformio debug -e m5stick-s3-debug`
+
+Log output already reaches that port as the secondary console,
+`CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG` is set in `sdkconfig.m5stick-s3`,
+so the monitor works over the same cable.
+
+The debugger halts the CPU. An active camera connection will drop while you sit
+on a breakpoint, and the task watchdog will complain. It logs rather than
+reboots.
+
+The other boards are plain ESP32 and reach the host through a USB to UART
+bridge. They have no JTAG peripheral, so their debug environments give verbose
+logging and unoptimised code only. There are no breakpoints on a StickC.
+
 ## Usage
 
 The top level menu has the following entries:

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,3 +39,39 @@ build_flags = ${furble.build_flags} -DFURBLE_M5COREX
 [env:m5stick-s3]
 board = esp32-s3-devkitc-1
 build_flags = ${furble.build_flags} -DFURBLE_M5STICKS3
+
+; Developer only environments. CI and releases build the five environments above.
+; Without an explicit path PlatformIO generates a fresh sdkconfig for each new
+; environment name, so every variant points back at the sdkconfig of the board it
+; extends. Only the compiler flags differ.
+[env:m5stick-c-debug]
+extends = env:m5stick-c
+board_build.esp-idf.sdkconfig_path = ${platformio.src_dir}/../sdkconfig.m5stick-c
+build_type = debug
+build_flags = ${env:m5stick-c.build_flags} -DLOG_LOCAL_LEVEL=ESP_LOG_VERBOSE
+
+[env:m5stick-c-plus-debug]
+extends = env:m5stick-c-plus
+board_build.esp-idf.sdkconfig_path = ${platformio.src_dir}/../sdkconfig.m5stick-c-plus
+build_type = debug
+build_flags = ${env:m5stick-c-plus.build_flags} -DLOG_LOCAL_LEVEL=ESP_LOG_VERBOSE
+
+[env:m5stack-core-debug]
+extends = env:m5stack-core
+board_build.esp-idf.sdkconfig_path = ${platformio.src_dir}/../sdkconfig.m5stack-core
+build_type = debug
+build_flags = ${env:m5stack-core.build_flags} -DLOG_LOCAL_LEVEL=ESP_LOG_VERBOSE
+
+[env:m5stack-core2-debug]
+extends = env:m5stack-core2
+board_build.esp-idf.sdkconfig_path = ${platformio.src_dir}/../sdkconfig.m5stack-core2
+build_type = debug
+build_flags = ${env:m5stack-core2.build_flags} -DLOG_LOCAL_LEVEL=ESP_LOG_VERBOSE
+
+[env:m5stick-s3-debug]
+extends = env:m5stick-s3
+board_build.esp-idf.sdkconfig_path = ${platformio.src_dir}/../sdkconfig.m5stick-s3
+build_type = debug
+build_flags = ${env:m5stick-s3.build_flags} -DLOG_LOCAL_LEVEL=ESP_LOG_VERBOSE
+debug_tool = esp-builtin
+debug_init_break = tbreak app_main


### PR DESCRIPTION
Motivation: I am working on power optimisation and need to see verbose logs and attach a debugger on the device I am tuning, over the single USB-C cable, without touching the release configurations.

Adds an optional <board>-debug PlatformIO environment for each of the five boards, with build_type = debug and LOG_LOCAL_LEVEL=ESP_LOG_VERBOSE, plus debug_tool = esp-builtin for the M5StickS3 so its built-in USB-Serial/JTAG can be used without extra hardware. Each variant reuses the sdkconfig of the release environment it extends, so no sdkconfig or source changes and the five release builds are unaffected.

Tested by building m5stick-s3, m5stick-c-plus, m5stick-s3-debug and m5stick-c-debug. The m5stick-s3-debug build was flashed to a M5StickS3 over USB and boots normally with debug level log output on the USB console. JTAG breakpoint debugging is not yet exercised.

Plan document: https://github.com/MaxRink/furble/blob/plans/plans/00b-dev-usb-debug.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)