### PR TITLE
Add power manager module

### DIFF
--- a/include/FurbleGPS.h
+++ b/include/FurbleGPS.h
@@ -1,11 +1,15 @@
 #ifndef FURBLE_GPS_H
 #define FURBLE_GPS_H
 
+#include <optional>
+
 #include <driver/uart.h>
 
 #include <lvgl.h>
 
 #include <TinyGPS++.h>
+
+#include "FurblePower.h"
 
 namespace Furble {
 class GPS {
@@ -36,6 +40,7 @@ class GPS {
   static constexpr const int QUEUE_SIZE = 32;
   static constexpr const uint16_t SERVICE_MS = 1000;
   static constexpr const uint32_t MAX_AGE_MS = 30 * 1000;
+  static constexpr const char *POWER_LOCK_OWNER = "gps";
 
   void enable(void);
   void disable(void);
@@ -53,6 +58,11 @@ class GPS {
   bool m_Enabled = false;
   bool m_HasFix = false;
   TinyGPSPlus m_GPS;
+
+#if defined(FURBLE_M5STICKS3)
+  // held while the receiver is powered, the ESP32S3 UART needs it
+  std::optional<Power::Lock> m_PowerLock;
+#endif
 };
 }  // namespace Furble
 

--- a/include/FurblePlatform.h
+++ b/include/FurblePlatform.h
@@ -1,11 +1,21 @@
 #ifndef FURBLE_PLATFORM_H
 #define FURBLE_PLATFORM_H
 
+#include <array>
+
+#include <esp_err.h>
+
 #include <M5PM1.h>
 
 namespace Furble {
 class Platform {
  public:
+  /** Selectable maximum CPU frequencies in MHz. */
+  static constexpr std::array<uint8_t, 3> CPU_MAX_FREQ_MHZ = {80, 160, 240};
+
+  /** Default maximum CPU frequency in MHz. */
+  static constexpr uint8_t CPU_MAX_FREQ_DEFAULT_MHZ = 160;
+
   static Platform &getInstance();
 
   Platform(Platform const &) = delete;
@@ -40,10 +50,32 @@ class Platform {
    */
   void setSleep(bool enable);
 
+  /**
+   * Set the maximum CPU frequency in MHz.
+   *
+   * Unsupported values fall back to the default. Use getCPUMaxFreq() to read
+   * back what was actually applied.
+   */
+  void setCPUMaxFreq(uint8_t mhz);
+
+  /**
+   * Get the maximum CPU frequency in MHz.
+   */
+  uint8_t getCPUMaxFreq(void) const;
+
  private:
   Platform() {};
 
-  const int CPU_MAX_FREQ_MHZ = 160;
+  /**
+   * Apply the power management configuration.
+   */
+  esp_err_t configurePM(uint8_t max_freq_mhz, bool sleep);
+
+  /**
+   * Is the frequency one we are prepared to ask for?
+   */
+  static bool isCPUMaxFreqValid(uint8_t mhz);
+
   const int CPU_MIN_FREQ_MHZ = 40;
 
   // Power button click streak threshold
@@ -53,6 +85,8 @@ class Platform {
 
   bool m_Init = false;
   bool m_PMICHack = false;
+  bool m_Sleep = true;
+  uint8_t m_CPUMaxFreqMHz = CPU_MAX_FREQ_DEFAULT_MHZ;
   uint8_t m_PMICClickCount = 0;
   uint32_t m_PMICClickTime = 0;
 };

--- a/include/FurblePlatform.h
+++ b/include/FurblePlatform.h
@@ -46,11 +46,6 @@ class Platform {
   void powerOff(void);
 
   /**
-   * Enable or disable automatic and light sleep.
-   */
-  void setSleep(bool enable);
-
-  /**
    * Set the maximum CPU frequency in MHz.
    *
    * Unsupported values fall back to the default. Use getCPUMaxFreq() to read
@@ -67,16 +62,9 @@ class Platform {
   Platform() {};
 
   /**
-   * Apply the power management configuration.
-   */
-  esp_err_t configurePM(uint8_t max_freq_mhz, bool sleep);
-
-  /**
    * Is the frequency one we are prepared to ask for?
    */
   static bool isCPUMaxFreqValid(uint8_t mhz);
-
-  const int CPU_MIN_FREQ_MHZ = 40;
 
   // Power button click streak threshold
   const uint8_t PWR_CLICK_THRESHOLD_MS = 20;
@@ -85,7 +73,6 @@ class Platform {
 
   bool m_Init = false;
   bool m_PMICHack = false;
-  bool m_Sleep = true;
   uint8_t m_CPUMaxFreqMHz = CPU_MAX_FREQ_DEFAULT_MHZ;
   uint8_t m_PMICClickCount = 0;
   uint32_t m_PMICClickTime = 0;

--- a/include/FurblePower.h
+++ b/include/FurblePower.h
@@ -1,0 +1,107 @@
+#ifndef FURBLE_POWER_H
+#define FURBLE_POWER_H
+
+#include <array>
+#include <atomic>
+
+#include <esp_err.h>
+#include <esp_pm.h>
+
+namespace Furble {
+class Power {
+ public:
+  /**
+   * Power management locks held by furble.
+   *
+   * The order must match m_Locks.
+   */
+  enum class LockType : uint8_t {
+    NO_LIGHT_SLEEP = 0,
+    CPU_FREQ_MAX = 1,
+    APB_FREQ_MAX = 2,
+  };
+
+  /**
+   * Hold a power management lock for the lifetime of the object.
+   */
+  class Lock {
+   public:
+    Lock(LockType type, const char *owner);
+    ~Lock();
+
+    Lock(Lock const &) = delete;
+    Lock(Lock &&) = delete;
+    Lock &operator=(Lock const &) = delete;
+    Lock &operator=(Lock &&) = delete;
+
+   private:
+    const LockType m_Type;
+    const char *const m_Owner;
+  };
+
+  static Power &getInstance();
+
+  Power(Power const &) = delete;
+  Power(Power &&) = delete;
+  Power &operator=(Power const &) = delete;
+  Power &operator=(Power &&) = delete;
+
+  static void init(void);
+
+  /**
+   * Apply the power management configuration.
+   *
+   * Automatic light sleep is always enabled, the NO_LIGHT_SLEEP lock is what
+   * inhibits it.
+   */
+  esp_err_t configure(uint8_t max_freq_mhz);
+
+  /**
+   * Acquire a lock, inhibiting the matching power saving.
+   *
+   * The locks are counted, every acquire needs a matching release. The owner
+   * string is for logging only and must be a static literal.
+   */
+  void acquire(LockType type, const char *owner);
+
+  /**
+   * Release a previously acquired lock.
+   */
+  void release(LockType type, const char *owner);
+
+  /**
+   * How many times is the lock currently held?
+   */
+  uint32_t getCount(LockType type) const;
+
+  /**
+   * Get the lock name for logging and diagnostics.
+   */
+  const char *getName(LockType type) const;
+
+ private:
+  Power() {};
+
+  typedef struct {
+    const esp_pm_lock_type_t type;
+    const char *const name;
+    esp_pm_lock_handle_t handle;
+    std::atomic<uint32_t> count;
+  } lock_t;
+
+  static constexpr const uint8_t CPU_MIN_FREQ_MHZ = 40;
+
+  const lock_t &getLock(LockType type) const;
+  lock_t &getLock(LockType type);
+
+  bool m_Init = false;
+
+  std::array<lock_t, 3> m_Locks = {
+      lock_t {ESP_PM_NO_LIGHT_SLEEP, "no_light_sleep", nullptr, 0},
+      lock_t {ESP_PM_CPU_FREQ_MAX,   "cpu_freq_max",   nullptr, 0},
+      lock_t {ESP_PM_APB_FREQ_MAX,   "apb_freq_max",   nullptr, 0},
+  };
+};
+}  // namespace Furble
+
+#endif

--- a/include/FurbleSettings.h
+++ b/include/FurbleSettings.h
@@ -26,6 +26,7 @@ class Settings {
     FAUXNY,
     TOUCH_CALIBRATION,
     AUTOCONNECT,
+    CPU_FREQ,
   } type_t;
 
   typedef struct {
@@ -61,6 +62,9 @@ class Settings {
 
   static constexpr uint32_t BAUD_9600 = 9600;
   static constexpr uint32_t BAUD_115200 = 115200;
+
+  /** Default maximum CPU frequency in MHz, matches Platform. */
+  static constexpr uint8_t CPU_FREQ_DEFAULT = 160;
 
   static void init(void);
 
@@ -145,6 +149,10 @@ struct Settings::storage_type<Settings::TOUCH_CALIBRATION> {
 template <>
 struct Settings::storage_type<Settings::AUTOCONNECT> {
   using type = bool;
+};
+template <>
+struct Settings::storage_type<Settings::CPU_FREQ> {
+  using type = uint8_t;
 };
 
 }  // namespace Furble

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -180,6 +180,7 @@ class UI {
   static constexpr const char *m_ThemeStr = "Theme";
   static constexpr const char *m_TransmitPowerStr = "TX Power";
   static constexpr const char *m_AboutStr = "About";
+  static constexpr const char *m_PowerStr = "Power";
 
   // settings->gps
   static constexpr const char *m_GPSDataStr = "GPS Data";
@@ -335,6 +336,9 @@ class UI {
   void addSpinnerPage(const menu_t &parent, const char *item, Intervalometer::Spinner &spinner);
 
   void addDisplayMenu(const menu_t &parent);
+
+  /** Add the 'Power' menu entry. */
+  void addPowerMenu(const menu_t &parent);
 
   void addThemeMenu(const menu_t &parent);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ set(furble_sources
     FurbleControl.cpp
     FurbleGPS.cpp
     FurblePlatform.cpp
+    FurblePower.cpp
     FurbleSettings.cpp
     FurbleSpinValue.cpp
     FurbleUI.cpp

--- a/src/FurbleGPS.cpp
+++ b/src/FurbleGPS.cpp
@@ -6,7 +6,7 @@
 
 #include "FurbleControl.h"
 #include "FurbleGPS.h"
-#include "FurblePlatform.h"
+#include "FurblePower.h"
 #include "FurbleSettings.h"
 
 void gps_task(void *param) {
@@ -119,7 +119,9 @@ void GPS::enable(void) {
 
 #if defined(FURBLE_M5STICKS3)
   // ESP32S3 UART does not function with light sleep
-  Platform::getInstance().setSleep(false);
+  if (!m_PowerLock.has_value()) {
+    m_PowerLock.emplace(Power::LockType::NO_LIGHT_SLEEP, POWER_LOCK_OWNER);
+  }
 #endif
 }
 
@@ -128,7 +130,7 @@ void GPS::disable(void) {
   M5.Power.setExtOutput(false, m5::ext_PA);
 
 #if defined(FURBLE_M5STICKS3)
-  Platform::getInstance().setSleep(true);
+  m_PowerLock.reset();
 #endif
 }
 

--- a/src/FurblePlatform.cpp
+++ b/src/FurblePlatform.cpp
@@ -1,11 +1,10 @@
 #include <algorithm>
 
-#include <esp_pm.h>
-
 #include <M5PM1.h>
 #include <M5Unified.h>
 
 #include "FurblePlatform.h"
+#include "FurblePower.h"
 #include "FurbleTypes.h"
 
 namespace Furble {
@@ -14,7 +13,8 @@ Platform &Platform::getInstance(void) {
   static Platform instance;
 
   if (!instance.m_Init) {
-    instance.setSleep(true);
+    Power::init();
+    instance.setCPUMaxFreq(CPU_MAX_FREQ_DEFAULT_MHZ);
 
     auto cfg = M5.config();
     cfg.clear_display = true;
@@ -65,22 +65,8 @@ uint8_t Platform::getPWRClickCount(void) {
   return count;
 }
 
-esp_err_t Platform::configurePM(uint8_t max_freq_mhz, bool sleep) {
-  esp_pm_config_t pm_config = {
-      .max_freq_mhz = max_freq_mhz,
-      .min_freq_mhz = CPU_MIN_FREQ_MHZ,
-      .light_sleep_enable = sleep,
-  };
-  return esp_pm_configure(&pm_config);
-}
-
 bool Platform::isCPUMaxFreqValid(uint8_t mhz) {
   return std::find(CPU_MAX_FREQ_MHZ.begin(), CPU_MAX_FREQ_MHZ.end(), mhz) != CPU_MAX_FREQ_MHZ.end();
-}
-
-void Platform::setSleep(bool enable) {
-  m_Sleep = enable;
-  ESP_ERROR_CHECK(configurePM(m_CPUMaxFreqMHz, enable));
 }
 
 void Platform::setCPUMaxFreq(uint8_t mhz) {
@@ -94,12 +80,13 @@ void Platform::setCPUMaxFreq(uint8_t mhz) {
   }
 
   // The board may still refuse the frequency, fall back rather than abort
-  esp_err_t err = configurePM(freq, m_Sleep);
+  auto &power = Power::getInstance();
+  esp_err_t err = power.configure(freq);
   if (err != ESP_OK) {
     ESP_LOGW(LOG_TAG, "CPU maximum frequency %dMHz rejected (%s), using %dMHz.", freq,
              esp_err_to_name(err), CPU_MAX_FREQ_DEFAULT_MHZ);
     freq = CPU_MAX_FREQ_DEFAULT_MHZ;
-    ESP_ERROR_CHECK(configurePM(freq, m_Sleep));
+    ESP_ERROR_CHECK(power.configure(freq));
   }
 
   m_CPUMaxFreqMHz = freq;

--- a/src/FurblePlatform.cpp
+++ b/src/FurblePlatform.cpp
@@ -1,9 +1,12 @@
+#include <algorithm>
+
 #include <esp_pm.h>
 
 #include <M5PM1.h>
 #include <M5Unified.h>
 
 #include "FurblePlatform.h"
+#include "FurbleTypes.h"
 
 namespace Furble {
 
@@ -62,13 +65,48 @@ uint8_t Platform::getPWRClickCount(void) {
   return count;
 }
 
-void Platform::setSleep(bool enable) {
+esp_err_t Platform::configurePM(uint8_t max_freq_mhz, bool sleep) {
   esp_pm_config_t pm_config = {
-      .max_freq_mhz = CPU_MAX_FREQ_MHZ,
+      .max_freq_mhz = max_freq_mhz,
       .min_freq_mhz = CPU_MIN_FREQ_MHZ,
-      .light_sleep_enable = enable,
+      .light_sleep_enable = sleep,
   };
-  ESP_ERROR_CHECK(esp_pm_configure(&pm_config));
+  return esp_pm_configure(&pm_config);
+}
+
+bool Platform::isCPUMaxFreqValid(uint8_t mhz) {
+  return std::find(CPU_MAX_FREQ_MHZ.begin(), CPU_MAX_FREQ_MHZ.end(), mhz) != CPU_MAX_FREQ_MHZ.end();
+}
+
+void Platform::setSleep(bool enable) {
+  m_Sleep = enable;
+  ESP_ERROR_CHECK(configurePM(m_CPUMaxFreqMHz, enable));
+}
+
+void Platform::setCPUMaxFreq(uint8_t mhz) {
+  uint8_t freq = mhz;
+
+  // NVS may hold anything, never hand an unvetted value to esp_pm_configure()
+  if (!isCPUMaxFreqValid(freq)) {
+    ESP_LOGW(LOG_TAG, "Unsupported CPU maximum frequency %dMHz, using %dMHz.", freq,
+             CPU_MAX_FREQ_DEFAULT_MHZ);
+    freq = CPU_MAX_FREQ_DEFAULT_MHZ;
+  }
+
+  // The board may still refuse the frequency, fall back rather than abort
+  esp_err_t err = configurePM(freq, m_Sleep);
+  if (err != ESP_OK) {
+    ESP_LOGW(LOG_TAG, "CPU maximum frequency %dMHz rejected (%s), using %dMHz.", freq,
+             esp_err_to_name(err), CPU_MAX_FREQ_DEFAULT_MHZ);
+    freq = CPU_MAX_FREQ_DEFAULT_MHZ;
+    ESP_ERROR_CHECK(configurePM(freq, m_Sleep));
+  }
+
+  m_CPUMaxFreqMHz = freq;
+}
+
+uint8_t Platform::getCPUMaxFreq(void) const {
+  return m_CPUMaxFreqMHz;
 }
 
 void Platform::powerOff(void) {

--- a/src/FurblePower.cpp
+++ b/src/FurblePower.cpp
@@ -1,0 +1,109 @@
+#include <esp_log.h>
+
+#include "FurblePower.h"
+#include "FurbleTypes.h"
+
+namespace Furble {
+
+Power &Power::getInstance(void) {
+  static Power instance;
+
+  if (!instance.m_Init) {
+    for (auto &lock : instance.m_Locks) {
+      esp_err_t err = esp_pm_lock_create(lock.type, 0, lock.name, &lock.handle);
+      if (err != ESP_OK) {
+        // no locks means no power saving control, log and carry on
+        ESP_LOGE(LOG_TAG, "Failed to create '%s' power lock (%s).", lock.name,
+                 esp_err_to_name(err));
+        lock.handle = nullptr;
+      }
+    }
+
+    instance.m_Init = true;
+  }
+
+  return instance;
+}
+
+void Power::init(void) {
+  (void)getInstance();
+}
+
+esp_err_t Power::configure(uint8_t max_freq_mhz) {
+  esp_pm_config_t pm_config = {
+      .max_freq_mhz = max_freq_mhz,
+      .min_freq_mhz = CPU_MIN_FREQ_MHZ,
+      .light_sleep_enable = true,
+  };
+  return esp_pm_configure(&pm_config);
+}
+
+const Power::lock_t &Power::getLock(LockType type) const {
+  return m_Locks[static_cast<size_t>(type)];
+}
+
+Power::lock_t &Power::getLock(LockType type) {
+  return m_Locks[static_cast<size_t>(type)];
+}
+
+void Power::acquire(LockType type, const char *owner) {
+  auto &lock = getLock(type);
+
+  if (lock.handle == nullptr) {
+    return;
+  }
+
+  esp_err_t err = esp_pm_lock_acquire(lock.handle);
+  if (err != ESP_OK) {
+    ESP_LOGE(LOG_TAG, "'%s' failed to acquire '%s' power lock (%s).", owner, lock.name,
+             esp_err_to_name(err));
+    return;
+  }
+
+  uint32_t count = ++lock.count;
+  ESP_LOGI(LOG_TAG, "'%s' acquired '%s' power lock, held %u times.", owner, lock.name,
+           (unsigned int)count);
+}
+
+void Power::release(LockType type, const char *owner) {
+  auto &lock = getLock(type);
+
+  if (lock.handle == nullptr) {
+    return;
+  }
+
+  if (lock.count == 0) {
+    // an unbalanced release is a bug, do not confuse esp_pm with it
+    ESP_LOGE(LOG_TAG, "'%s' released unheld '%s' power lock.", owner, lock.name);
+    return;
+  }
+
+  esp_err_t err = esp_pm_lock_release(lock.handle);
+  if (err != ESP_OK) {
+    ESP_LOGE(LOG_TAG, "'%s' failed to release '%s' power lock (%s).", owner, lock.name,
+             esp_err_to_name(err));
+    return;
+  }
+
+  uint32_t count = --lock.count;
+  ESP_LOGI(LOG_TAG, "'%s' released '%s' power lock, held %u times.", owner, lock.name,
+           (unsigned int)count);
+}
+
+uint32_t Power::getCount(LockType type) const {
+  return getLock(type).count;
+}
+
+const char *Power::getName(LockType type) const {
+  return getLock(type).name;
+}
+
+Power::Lock::Lock(LockType type, const char *owner) : m_Type(type), m_Owner(owner) {
+  Power::getInstance().acquire(m_Type, m_Owner);
+}
+
+Power::Lock::~Lock() {
+  Power::getInstance().release(m_Type, m_Owner);
+}
+
+}  // namespace Furble

--- a/src/FurbleSettings.cpp
+++ b/src/FurbleSettings.cpp
@@ -21,6 +21,7 @@ const std::unordered_map<Settings::type_t, Settings::setting_t> Settings::m_Sett
     {FAUXNY,            {FAUXNY, "FauxNY", "fauxNY", FURBLE_STR}                       },
     {TOUCH_CALIBRATION, {TOUCH_CALIBRATION, "Touch Calibration", "t_calib", FURBLE_STR}},
     {AUTOCONNECT,       {AUTOCONNECT, "Auto-Connect", "autoconnect", FURBLE_STR}       },
+    {CPU_FREQ,          {CPU_FREQ, "CPU Speed", "cpu_freq", FURBLE_STR}                },
 };
 
 const Settings::setting_t &Settings::get(type_t type) {
@@ -215,6 +216,9 @@ void Settings::init(void) {
           break;
         case GPS_BAUD:
           save<uint32_t>(setting.type, BAUD_9600);
+          break;
+        case CPU_FREQ:
+          save<uint8_t>(setting.type, CPU_FREQ_DEFAULT);
           break;
         case TOUCH_CALIBRATION:
         {

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -69,6 +69,7 @@ std::unordered_map<const char *, UI::menu_t> UI::m_Menu = {
     {m_ThemeStr,             {nullptr, nullptr, nullptr, nullptr, {0, 1}}},
     {m_TransmitPowerStr,     {nullptr, nullptr, nullptr, nullptr, {1, 1}}},
     {m_AboutStr,             {nullptr, nullptr, nullptr, nullptr, {2, 1}}},
+    {m_PowerStr,             {nullptr, nullptr, nullptr, nullptr, {3, 1}}},
     {m_RemoteShutter,        {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_RemoteInterval,       {nullptr, nullptr, nullptr, nullptr, {1, 0}}},
     {m_RemoteDisconnect,     {nullptr, nullptr, nullptr, nullptr, {2, 0}}},
@@ -1949,6 +1950,61 @@ void UI::addDisplayMenu(const menu_t &parent) {
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }
 
+void UI::addPowerMenu(const menu_t &parent) {
+  menu_t &menu = addMenu(m_PowerStr, &icon_power_settings_new, true, parent);
+  lv_obj_t *cont = lv_menu_cont_create(menu.page);
+  lv_obj_set_height(cont, LV_PCT(100));
+  lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+
+  // Add CPU maximum frequency control
+  lv_obj_t *label = lv_label_create(cont);
+  lv_label_set_text(label, "CPU speed");
+  lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+  lv_obj_set_width(label, LV_PCT(100));
+
+  const auto &frequencies = Platform::CPU_MAX_FREQ_MHZ;
+  std::string options;
+  for (const auto mhz : frequencies) {
+    if (!options.empty()) {
+      options += "\n";
+    }
+    options += std::to_string(mhz) + " MHz";
+  }
+
+  lv_obj_t *roller = lv_roller_create(cont);
+  lv_obj_set_width(roller, LV_PCT(90));
+  lv_roller_set_options(roller, options.c_str(), LV_ROLLER_MODE_INFINITE);
+  lv_roller_set_visible_row_count(roller, 2);
+
+  // The roller index is not the frequency, map it explicitly
+  // getCPUMaxFreq() only ever returns a listed frequency, so the find succeeds
+  auto &platform = Platform::getInstance();
+  uint32_t index =
+      std::distance(frequencies.begin(),
+                    std::find(frequencies.begin(), frequencies.end(), platform.getCPUMaxFreq()));
+  lv_roller_set_selected(roller, index, LV_ANIM_OFF);
+
+  lv_obj_add_event_cb(
+      roller,
+      [](lv_event_t *e) {
+        auto *roller = static_cast<lv_obj_t *>(lv_event_get_target(e));
+        auto index = lv_roller_get_selected(roller);
+        if (index >= Platform::CPU_MAX_FREQ_MHZ.size()) {
+          return;
+        }
+
+        // Takes effect immediately, save what was actually applied
+        auto &platform = Platform::getInstance();
+        platform.setCPUMaxFreq(Platform::CPU_MAX_FREQ_MHZ[index]);
+        Settings::save<Settings::CPU_FREQ>(platform.getCPUMaxFreq());
+      },
+      LV_EVENT_VALUE_CHANGED, NULL);
+
+  lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
+}
+
 void UI::addThemeMenu(const menu_t &parent) {
   menu_t &menu = addMenu(m_ThemeStr, &icon_palette, true, parent);
 
@@ -2077,6 +2133,7 @@ void UI::addSettingsMenu(void) {
   addThemeMenu(menu);
   addTransmitPowerMenu(menu);
   addAboutMenu(menu);
+  addPowerMenu(menu);
 
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,11 @@ void app_main() {
 
   Furble::Platform::init();
   Furble::Settings::init();
+
+  // Platform::init() runs before NVS exists, apply the stored frequency now
+  Furble::Platform::getInstance().setCPUMaxFreq(
+      Furble::Settings::load<Furble::Settings::CPU_FREQ>());
+
   Furble::Device::init(Furble::Settings::load<esp_power_level_t>(Furble::Settings::TX_POWER));
 
   auto &control = Furble::Control::getInstance();


### PR DESCRIPTION
Motivation: enabling GPS on the M5StickS3 switches light sleep off for the whole device, which costs a large share of my battery. Fixing that, and the sleep work that should follow, needs subsystems to express "keep me awake" individually instead of flipping one global switch.

Adds a FurblePower module that owns the esp_pm configuration and the counted ESP-IDF power management locks, with a scoped Lock helper so a lock cannot leak. GPS now holds a named NO_LIGHT_SLEEP lock while the receiver is powered instead of switching light sleep off globally, so the sleep state is unchanged on every board with GPS on or off. Depends on #287 for the CPU frequency value it applies.

Build verified on all five environments. Not yet hardware tested; on-device verification of the GPS on/off sleep states on a M5StickS3 will follow. No camera vendor code is touched.

Plan document: https://github.com/MaxRink/furble/blob/plans/plans/06-power-module.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)