### PR TITLE
Add a bulb timer to the connected page

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,21 @@ Delay and shutter time can be figured with custom or preset values from 0 to 999
 
 Some camera protocols such as Ricoh GR trigger capture with a single operation request and do not expose separate exposure start/stop control. For those cameras the intervalometer still controls the wait, count, and delay between captures, but the camera ignores the configured shutter-open duration.
 
+### Bulb
+
+`Bulb` on the connected menu holds the shutter open for a set time, which saves
+watching a stopwatch during a long exposure.
+
+Set the length under `Bulb->Duration`, then hit `Start`.
+The page counts down and the shutter is released at zero.
+The duration is remembered for next time and defaults to 30 seconds.
+
+`Stop` ends the exposure early, and leaving the page also releases the shutter,
+so an exposure never keeps running out of sight.
+
+The camera must be in bulb mode, otherwise it will end the exposure on its own
+and the countdown will simply run out.
+
 ### Shutter Lock
 
 When in `Shutter` remote control, holding focus (button B) then release (button A) will engage shutter lock, holding the shutter open until a button is pressed.

--- a/include/FurbleSettings.h
+++ b/include/FurbleSettings.h
@@ -26,6 +26,7 @@ class Settings {
     FAUXNY,
     TOUCH_CALIBRATION,
     AUTOCONNECT,
+    BULB,
   } type_t;
 
   typedef struct {
@@ -61,6 +62,8 @@ class Settings {
 
   static constexpr uint32_t BAUD_9600 = 9600;
   static constexpr uint32_t BAUD_115200 = 115200;
+
+  static constexpr SpinValue::nvs_t BULB_DEFAULT = {30, SpinValue::UNIT_SEC};
 
   static void init(void);
 
@@ -145,6 +148,10 @@ struct Settings::storage_type<Settings::TOUCH_CALIBRATION> {
 template <>
 struct Settings::storage_type<Settings::AUTOCONNECT> {
   using type = bool;
+};
+template <>
+struct Settings::storage_type<Settings::BULB> {
+  using type = SpinValue::nvs_t;
 };
 
 }  // namespace Furble

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -74,12 +74,25 @@ class UI {
     bool screenLocked;
   } status_t;
 
-  class Intervalometer {
+  /**
+   * Owner of a spinner.
+   *
+   * A spinner edit saves through its owner, so each owner writes only its own
+   * setting.
+   */
+  class SpinnerOwner {
+   public:
+    virtual ~SpinnerOwner() = default;
+
+    virtual void save(void) = 0;
+  };
+
+  class Intervalometer: public SpinnerOwner {
    public:
     class Spinner {
      public:
-      Spinner(Intervalometer *intervalometer, SpinValue::nvs_t nvs, bool infinite = false)
-          : m_Intervalometer {intervalometer}, m_SpinValue {nvs}, m_Infinite {infinite} {};
+      Spinner(SpinnerOwner *owner, SpinValue::nvs_t nvs, bool infinite = false)
+          : m_Owner {owner}, m_SpinValue {nvs}, m_Infinite {infinite} {};
 
       static constexpr const char *m_SpinDigitRoller = "0\n1\n2\n3\n4\n5\n6\n7\n8\n9";
       static constexpr const char *m_SpinUnitsRoller = "msec\nsecs\nmins";
@@ -87,7 +100,7 @@ class UI {
       void update(void);
       void updateLabels(void);
 
-      Intervalometer *m_Intervalometer;
+      SpinnerOwner *m_Owner;
       SpinValue m_SpinValue;
       lv_obj_t *m_Button;
       lv_obj_t *m_Label;
@@ -112,7 +125,7 @@ class UI {
 
     Intervalometer(const interval_t &interval);
 
-    void save(void);
+    void save(void) override;
 
     state_t m_State;
     Spinner m_Count;
@@ -123,6 +136,20 @@ class UI {
     lv_obj_t *m_StateLabel;
     lv_obj_t *m_CountLabel;
     lv_obj_t *m_RemainingLabel;
+  };
+
+  /**
+   * Bulb exposure, holds the shutter open for a set duration.
+   */
+  class Bulb: public SpinnerOwner {
+   public:
+    Bulb(const SpinValue::nvs_t &duration);
+
+    void save(void) override;
+
+    Intervalometer::Spinner m_Duration;
+
+    lv_obj_t *m_RemainingLabel = nullptr;
   };
 
   typedef enum { MODE_SCAN, MODE_DELETE, MODE_CONNECT, MODE_MULTICONNECT } CameraListMode_t;
@@ -167,11 +194,16 @@ class UI {
   // connected
   static constexpr const char *m_ConnectedStr = "Connected";
   static constexpr const char *m_RemoteShutter = "Remote";
+  static constexpr const char *m_RemoteBulb = "Bulb";
   static constexpr const char *m_RemoteInterval = "Interval";
   static constexpr const char *m_RemoteDisconnect = "Disconnect";
   // dodgy hack, add a space so map key is unique
   static constexpr const char *m_RemoteGPSData = "GPS Data ";
   static constexpr const char *m_IntervalometerRunStr = "Intervalometer ";
+  static constexpr const char *m_BulbRunStr = "Bulb ";
+
+  // connected->bulb
+  static constexpr const char *m_BulbDurationStr = "Duration";
 
   // settings
   static constexpr const char *m_DisplayStr = "Display";
@@ -212,6 +244,10 @@ class UI {
   static lv_timer_t *m_IntervalPageRefresh;
   static uint32_t m_IntervalNext;
 
+  static lv_timer_t *m_BulbTimer;
+  static lv_timer_t *m_BulbPageRefresh;
+  static uint32_t m_BulbEnd;
+
   lv_timer_t *m_IntervalTimer;
   lv_timer_t *m_InactivityTimer;
   lv_timer_t *m_IconTimer;
@@ -249,6 +285,9 @@ class UI {
 
   lv_obj_t *m_IntervalStart = nullptr;
   Intervalometer m_Intervalometer;
+
+  lv_obj_t *m_BulbStart = nullptr;
+  Bulb m_Bulb;
 
   status_t m_Status;
   bool m_FocusPressed = false;
@@ -329,6 +368,15 @@ class UI {
 
   /** Add the 'Intervalometer' menu entry. */
   void addIntervalometerMenu(const menu_t &parent);
+
+  /** Add the 'Bulb' menu entry. */
+  void addBulbMenu(const menu_t &parent);
+
+  /** Refresh the bulb exposure countdown. */
+  void bulbRefresh(void);
+
+  /** Stop any bulb exposure and release the shutter. */
+  void bulbStop(void);
 
   /** Add spinner menu item entry. */
   lv_obj_t *addSpinItem(lv_obj_t *page, const char *item, Intervalometer::Spinner &spinner);

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -170,6 +170,7 @@ class UI {
   static constexpr const char *m_RemoteInterval = "Interval";
   static constexpr const char *m_RemoteDisconnect = "Disconnect";
   // dodgy hack, add a space so map key is unique
+  static constexpr const char *m_RemoteGPSData = "GPS Data ";
   static constexpr const char *m_IntervalometerRunStr = "Intervalometer ";
 
   // settings
@@ -207,6 +208,7 @@ class UI {
   LV_ATTRIBUTE_MEM_ALIGN void *m_Buffer2;
 
   static lv_timer_t *m_ConnectTimer;
+  static lv_timer_t *m_GPSDataTimer;
   static lv_timer_t *m_IntervalPageRefresh;
   static uint32_t m_IntervalNext;
 
@@ -350,6 +352,9 @@ class UI {
 
   /** Update entries in connect page. */
   static void updateItems(const menu_t &menu);
+
+  /** Start GPS Data timer. */
+  static void gpsDataStart(lv_event_t *e);
 
   /** Stop GPS Data timer. */
   static void gpsDataStop(lv_event_t *e);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set(furble_sources
     FurbleSettings.cpp
     FurbleSpinValue.cpp
     FurbleUI.cpp
+    FurbleUIBulb.cpp
     FurbleUIIntervalometer.cpp
     main.cpp)
 

--- a/src/FurbleSettings.cpp
+++ b/src/FurbleSettings.cpp
@@ -21,6 +21,7 @@ const std::unordered_map<Settings::type_t, Settings::setting_t> Settings::m_Sett
     {FAUXNY,            {FAUXNY, "FauxNY", "fauxNY", FURBLE_STR}                       },
     {TOUCH_CALIBRATION, {TOUCH_CALIBRATION, "Touch Calibration", "t_calib", FURBLE_STR}},
     {AUTOCONNECT,       {AUTOCONNECT, "Auto-Connect", "autoconnect", FURBLE_STR}       },
+    {BULB,              {BULB, "Bulb", "bulb", FURBLE_STR}                             },
 };
 
 const Settings::setting_t &Settings::get(type_t type) {
@@ -85,6 +86,23 @@ interval_t Settings::load<interval_t>(type_t type) {
   m_Prefs.end();
 
   return interval;
+}
+
+template <>
+SpinValue::nvs_t Settings::load<SpinValue::nvs_t>(type_t type) {
+  const auto &setting = get(type);
+  SpinValue::nvs_t nvs;
+
+  m_Prefs.begin(setting.nvs_namespace, true);
+  size_t len = m_Prefs.get(setting.key, &nvs, sizeof(SpinValue::nvs_t));
+  if (len != sizeof(SpinValue::nvs_t)) {
+    // default value
+    nvs = BULB_DEFAULT;
+  }
+
+  m_Prefs.end();
+
+  return nvs;
 }
 
 template <>
@@ -154,6 +172,14 @@ void Settings::save<interval_t>(const type_t type, const interval_t &value) {
 }
 
 template <>
+void Settings::save<SpinValue::nvs_t>(const type_t type, const SpinValue::nvs_t &value) {
+  const auto &setting = get(type);
+  m_Prefs.begin(setting.nvs_namespace, false);
+  m_Prefs.put(setting.key, &value, sizeof(value));
+  m_Prefs.end();
+}
+
+template <>
 void Settings::save<std::string>(const type_t type, const std::string &value) {
   saveValue<std::string>(type, value);
 }
@@ -206,6 +232,9 @@ void Settings::init(void) {
           };
           save<interval_t>(setting.type, interval);
         } break;
+        case BULB:
+          save<SpinValue::nvs_t>(setting.type, BULB_DEFAULT);
+          break;
         case GPS:
         case MULTICONNECT:
         case RECONNECT:

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -50,6 +50,10 @@ lv_timer_t *UI::m_GPSDataTimer;
 lv_timer_t *UI::m_IntervalPageRefresh;
 uint32_t UI::m_IntervalNext;
 
+lv_timer_t *UI::m_BulbTimer;
+lv_timer_t *UI::m_BulbPageRefresh;
+uint32_t UI::m_BulbEnd;
+
 UI::menu_t UI::m_MainMenu;
 
 std::unordered_map<const char *, UI::menu_t> UI::m_Menu = {
@@ -72,15 +76,19 @@ std::unordered_map<const char *, UI::menu_t> UI::m_Menu = {
     {m_TransmitPowerStr,     {nullptr, nullptr, nullptr, nullptr, {1, 1}}},
     {m_AboutStr,             {nullptr, nullptr, nullptr, nullptr, {2, 1}}},
     {m_RemoteShutter,        {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
-    {m_RemoteInterval,       {nullptr, nullptr, nullptr, nullptr, {1, 0}}},
+    {m_RemoteBulb,           {nullptr, nullptr, nullptr, nullptr, {1, 0}}},
+    {m_RemoteInterval,       {nullptr, nullptr, nullptr, nullptr, {2, 0}}},
     {m_RemoteGPSData,        {nullptr, nullptr, nullptr, nullptr, {0, 1}}},
-    {m_RemoteDisconnect,     {nullptr, nullptr, nullptr, nullptr, {1, 1}}},
+    {m_RemoteDisconnect,     {nullptr, nullptr, nullptr, nullptr, {2, 1}}},
     {m_IntervalometerRunStr, {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
+    {m_BulbRunStr,           {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
+    {m_BulbDurationStr,      {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
 };
 
 UI::UI(const interval_t &interval)
     : m_GPS {GPS::getInstance()},
       m_Intervalometer(interval),
+      m_Bulb(Settings::load<Settings::BULB>()),
       m_CalibrationUI(M5.Display.width(), M5.Display.height()) {
   lv_init();
   lv_tick_set_cb(tick);
@@ -896,6 +904,11 @@ void UI::addMainMenu(void) {
         auto *back = lv_menu_get_main_header_back_button(m_MainMenu.main);
         auto &scan = Scan::getInstance();
 
+        // a bulb exposure only runs on its own page, never strand a held shutter
+        if (page != m_Menu.at(m_BulbRunStr).page) {
+          ui->bulbStop();
+        }
+
         if (page == m_MainMenu.page) {
           size_t saveCount = CameraList::getSaveCount();
           ui->m_MainCount++;
@@ -977,6 +990,11 @@ void UI::addMainMenu(void) {
             // hide the back button
             lv_obj_add_flag(back, LV_OBJ_FLAG_HIDDEN);
           }
+        } else if ((page == m_Menu.at(m_RemoteBulb).page)
+                   || (page == m_Menu.at(m_BulbRunStr).page)) {
+          // bulb is reachable from the connected page, always display 'Back'
+          lv_obj_remove_state(back, LV_STATE_DISABLED);
+          lv_obj_clear_flag(back, LV_OBJ_FLAG_HIDDEN);
         } else if (page == m_Menu.at(m_IntervalometerStr).page) {
           // always display 'Back' in intervalometer
           lv_obj_remove_state(back, LV_STATE_DISABLED);
@@ -1263,6 +1281,10 @@ void UI::doConnect(lv_event_t *e) {
 
 void UI::doDisconnect(void) {
   lv_timer_pause(m_ConnectTimer);
+
+  // release a held bulb exposure before the connection goes away
+  m_ConnectContext.ui->bulbStop();
+
   Scan::getInstance().stop();
   Control::getInstance().disconnect();
 
@@ -1279,7 +1301,9 @@ UI::menu_t &UI::addConnectedMenu(void) {
   menu_t &menuConnected = addMenu(m_ConnectedStr, NULL, false);
 
 #if defined(FURBLE_M5COREX)
-  static int32_t column_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+  // three by two suits the landscape screens, the gap falls in the bottom middle
+  static int32_t column_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
+                                 LV_GRID_TEMPLATE_LAST};
   static int32_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
   lv_obj_set_grid_dsc_array(menuConnected.page, column_dsc, row_dsc);
   lv_obj_center(menuConnected.page);
@@ -1287,6 +1311,7 @@ UI::menu_t &UI::addConnectedMenu(void) {
 #endif
 
   menu_t &menuShutter = addMenu(m_RemoteShutter, &icon_remote_gen, true, menuConnected);
+  addBulbMenu(menuConnected);
   menu_t &menuInterval = addMenu(m_RemoteInterval, &icon_timer, true, menuConnected);
   menu_t &menuGPSData = addMenu(m_RemoteGPSData, &icon_location_searching, true, menuConnected);
   menu_t &disconnect = addMenu(m_RemoteDisconnect, &icon_no_photography, true, menuConnected);
@@ -1861,6 +1886,102 @@ void UI::addIntervalometerMenu(const menu_t &parent) {
   lv_timer_pause(m_IntervalPageRefresh);
 
   lv_menu_set_load_page_event(menuIntervalRun.main, m_IntervalStart, menuIntervalRun.page);
+
+  lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
+}
+
+void UI::bulbRefresh(void) {
+  uint32_t now = tick();
+  uint32_t remaining = m_BulbEnd > now ? m_BulbEnd - now : 0;
+  SpinValue::hms_t hms = SpinValue::toHMS(remaining);
+  lv_label_set_text_fmt(m_Bulb.m_RemainingLabel, "%02lu:%02lu:%02lu", hms.hours, hms.minutes,
+                        hms.seconds);
+}
+
+void UI::bulbStop(void) {
+  lv_timer_pause(m_BulbTimer);
+  lv_timer_pause(m_BulbPageRefresh);
+
+  // no-op if the shutter is not held
+  shutterUnlock(Control::getInstance());
+
+  m_BulbEnd = tick();
+  bulbRefresh();
+}
+
+void UI::addBulbMenu(const menu_t &parent) {
+  menu_t &menu = addMenu(m_RemoteBulb, &icon_camera, true, parent);
+  menu_t &menuBulbRun = addMenu(m_BulbRunStr, NULL, false, menu);
+
+  addSpinnerPage(menu, m_BulbDurationStr, m_Bulb.m_Duration);
+
+  m_BulbStart = lv_button_create(menu.page);
+  lv_obj_t *startLabel = lv_label_create(m_BulbStart);
+  lv_label_set_text(startLabel, "Start");
+  lv_obj_center(startLabel);
+
+  lv_obj_add_event_cb(
+      m_BulbStart,
+      [](lv_event_t *e) {
+        auto *ui = static_cast<UI *>(lv_event_get_user_data(e));
+        uint32_t duration = ui->m_Bulb.m_Duration.m_SpinValue.toMilliseconds();
+
+        // hold the shutter with the same lock the remote page uses
+        ui->shutterLock(Control::getInstance());
+
+        m_BulbEnd = tick() + duration;
+        lv_timer_set_period(m_BulbTimer, duration);
+        lv_timer_reset(m_BulbTimer);
+        lv_timer_resume(m_BulbTimer);
+
+        ui->bulbRefresh();
+        lv_timer_resume(m_BulbPageRefresh);
+      },
+      LV_EVENT_CLICKED, this);
+
+  lv_obj_t *cont = lv_menu_cont_create(menuBulbRun.page);
+  lv_obj_set_height(cont, LV_PCT(100));
+  lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+
+  m_Bulb.m_RemainingLabel = lv_label_create(cont);
+
+  lv_obj_t *stop = lv_button_create(cont);
+  lv_obj_t *stopLabel = lv_label_create(stop);
+  lv_label_set_text(stopLabel, "Stop");
+  lv_obj_add_event_cb(
+      stop,
+      [](lv_event_t *e) {
+        auto *ui = static_cast<UI *>(lv_event_get_user_data(e));
+
+        // release the shutter and exit
+        ui->bulbStop();
+        lv_obj_t *back = lv_menu_get_main_header_back_button(m_MainMenu.main);
+        lv_obj_send_event(back, LV_EVENT_CLICKED, m_MainMenu.main);
+      },
+      LV_EVENT_CLICKED, this);
+
+  // one shot exposure timer, the period is the exposure duration
+  m_BulbTimer = lv_timer_create(
+      [](lv_timer_t *timer) {
+        auto *ui = static_cast<UI *>(lv_timer_get_user_data(timer));
+        ui->bulbStop();
+      },
+      1000, this);
+  lv_timer_pause(m_BulbTimer);
+
+  m_BulbPageRefresh = lv_timer_create(
+      [](lv_timer_t *timer) {
+        auto *ui = static_cast<UI *>(lv_timer_get_user_data(timer));
+        ui->bulbRefresh();
+      },
+      333, this);
+  lv_timer_pause(m_BulbPageRefresh);
+
+  bulbRefresh();
+
+  lv_menu_set_load_page_event(menuBulbRun.main, m_BulbStart, menuBulbRun.page);
 
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -45,6 +45,8 @@ UI::ConnectContext_t UI::m_ConnectContext;
 
 lv_timer_t *UI::m_ConnectTimer;
 
+lv_timer_t *UI::m_GPSDataTimer;
+
 lv_timer_t *UI::m_IntervalPageRefresh;
 uint32_t UI::m_IntervalNext;
 
@@ -71,7 +73,8 @@ std::unordered_map<const char *, UI::menu_t> UI::m_Menu = {
     {m_AboutStr,             {nullptr, nullptr, nullptr, nullptr, {2, 1}}},
     {m_RemoteShutter,        {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_RemoteInterval,       {nullptr, nullptr, nullptr, nullptr, {1, 0}}},
-    {m_RemoteDisconnect,     {nullptr, nullptr, nullptr, nullptr, {2, 0}}},
+    {m_RemoteGPSData,        {nullptr, nullptr, nullptr, nullptr, {0, 1}}},
+    {m_RemoteDisconnect,     {nullptr, nullptr, nullptr, nullptr, {1, 1}}},
     {m_IntervalometerRunStr, {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
 };
 
@@ -956,6 +959,13 @@ void UI::addMainMenu(void) {
           // Ensure no active scans
           scan.stop();
 
+          // only offer GPS data when GPS is enabled
+          if (ui->m_GPS.isEnabled()) {
+            lv_obj_clear_flag(m_Menu.at(m_RemoteGPSData).button, LV_OBJ_FLAG_HIDDEN);
+          } else {
+            lv_obj_add_flag(m_Menu.at(m_RemoteGPSData).button, LV_OBJ_FLAG_HIDDEN);
+          }
+
           // hide and disable back button
           lv_obj_add_state(back, LV_STATE_DISABLED);
           lv_obj_add_flag(back, LV_OBJ_FLAG_HIDDEN);
@@ -972,6 +982,9 @@ void UI::addMainMenu(void) {
           lv_obj_remove_state(back, LV_STATE_DISABLED);
         } else if (page == m_Menu.at(m_IntervalometerRunStr).page) {
           // disable 'Back' when intervalometer is running
+          lv_obj_remove_state(back, LV_STATE_DISABLED);
+        } else if (page == m_Menu.at(m_GPSDataStr).page) {
+          // 'GPS Data' is reachable from the connected page, always display 'Back'
           lv_obj_remove_state(back, LV_STATE_DISABLED);
         }
       },
@@ -1266,9 +1279,8 @@ UI::menu_t &UI::addConnectedMenu(void) {
   menu_t &menuConnected = addMenu(m_ConnectedStr, NULL, false);
 
 #if defined(FURBLE_M5COREX)
-  static int32_t column_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
-                                 LV_GRID_TEMPLATE_LAST};
-  static int32_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
+  static int32_t column_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+  static int32_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
   lv_obj_set_grid_dsc_array(menuConnected.page, column_dsc, row_dsc);
   lv_obj_center(menuConnected.page);
   lv_obj_set_layout(menuConnected.page, LV_LAYOUT_GRID);
@@ -1276,6 +1288,7 @@ UI::menu_t &UI::addConnectedMenu(void) {
 
   menu_t &menuShutter = addMenu(m_RemoteShutter, &icon_remote_gen, true, menuConnected);
   menu_t &menuInterval = addMenu(m_RemoteInterval, &icon_timer, true, menuConnected);
+  menu_t &menuGPSData = addMenu(m_RemoteGPSData, &icon_location_searching, true, menuConnected);
   menu_t &disconnect = addMenu(m_RemoteDisconnect, &icon_no_photography, true, menuConnected);
 
   if (M5.Touch.isEnabled()) {
@@ -1411,6 +1424,11 @@ UI::menu_t &UI::addConnectedMenu(void) {
         ui->showShutterIntervalometer(true);
       },
       LV_EVENT_CLICKED, this);
+
+  // add GPS data control, the page is shared with the settings menu
+  menu_t &menuGPSDataPage = m_Menu.at(m_GPSDataStr);
+  lv_menu_set_load_page_event(menuGPSDataPage.main, menuGPSData.button, menuGPSDataPage.page);
+  lv_obj_add_event_cb(menuGPSData.button, gpsDataStart, LV_EVENT_CLICKED, m_GPSDataTimer);
 
   // add disconnect control
   lv_obj_add_event_cb(
@@ -1552,7 +1570,7 @@ void UI::addGPSMenu(const menu_t &parent) {
     lv_obj_add_flag(m_Status.gpsData, LV_OBJ_FLAG_HIDDEN);
   }
 
-  static lv_timer_t *timer = lv_timer_create(
+  m_GPSDataTimer = lv_timer_create(
       [](lv_timer_t *t) {
         auto *gpsData = static_cast<menu_t *>(lv_timer_get_user_data(t));
         auto &gps = GPS::getInstance().get();
@@ -1587,20 +1605,19 @@ void UI::addGPSMenu(const menu_t &parent) {
 #endif
       },
       1000, &gpsData);
-  lv_timer_pause(timer);
+  lv_timer_pause(m_GPSDataTimer);
 
   // start the update timer on 'GPS Data' button press
-  lv_obj_add_event_cb(
-      gpsData.button,
-      [](lv_event_t *e) {
-        auto *timer = static_cast<lv_timer_t *>(lv_event_get_user_data(e));
-        lv_timer_resume(timer);
-        menu_t *menu = static_cast<menu_t *>(lv_timer_get_user_data(timer));
-        lv_obj_add_event_cb(menu->main, gpsDataStop, LV_EVENT_CLICKED, timer);
-      },
-      LV_EVENT_CLICKED, timer);
+  lv_obj_add_event_cb(gpsData.button, gpsDataStart, LV_EVENT_CLICKED, m_GPSDataTimer);
 
   lv_menu_set_load_page_event(gpsData.main, gpsData.button, gpsData.page);
+}
+
+void UI::gpsDataStart(lv_event_t *e) {
+  auto *timer = static_cast<lv_timer_t *>(lv_event_get_user_data(e));
+  lv_timer_resume(timer);
+  menu_t *menu = static_cast<menu_t *>(lv_timer_get_user_data(timer));
+  lv_obj_add_event_cb(menu->main, gpsDataStop, LV_EVENT_CLICKED, timer);
 }
 
 void UI::gpsDataStop(lv_event_t *e) {

--- a/src/FurbleUIBulb.cpp
+++ b/src/FurbleUIBulb.cpp
@@ -1,0 +1,14 @@
+#include <lvgl.h>
+
+#include "FurbleSettings.h"
+#include "FurbleUI.h"
+
+namespace Furble {
+
+UI::Bulb::Bulb(const SpinValue::nvs_t &duration) : m_Duration(this, duration) {}
+
+void UI::Bulb::save(void) {
+  Settings::save<Settings::BULB>(m_Duration.m_SpinValue.toNVS());
+}
+
+}  // namespace Furble

--- a/src/FurbleUIIntervalometer.cpp
+++ b/src/FurbleUIIntervalometer.cpp
@@ -48,7 +48,7 @@ void UI::Intervalometer::Spinner::update(void) {
   }
   updateLabels();
 
-  m_Intervalometer->save();
+  m_Owner->save();
 }
 
 void UI::Intervalometer::Spinner::updateLabels(void) {


### PR DESCRIPTION
Long exposures currently need a stopwatch and a steady hand, since the remote page can hold the shutter open but nothing releases it after a set time. This adds a Bulb page to the connected menu which opens the shutter, counts down, and releases at zero, with a stop button and a release on every exit path. The duration reuses the existing spinner, so Spinner now saves through an owner interface and a bulb edit no longer overwrites the intervalometer settings. The intervalometer can already hold the shutter for its Shutter duration, so the overlap is deliberate: the value here is a direct control that leaves the saved interval settings alone and a countdown that reads as an exposure. Depends on #289 as reworked, which added GPS Data to the connected page; this extends that grid to three by two.

Build verified on all five environments. Not tested on hardware yet, and bulb behaviour depends on the camera being in a mode that honours a held shutter.

Plan document: https://github.com/MaxRink/furble/blob/plans/plans/04-bulb-timer.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)