### PR TITLE
Add BLE scan duty cycle presets and scan timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,25 @@ Some camera protocols such as Ricoh GR trigger capture with a single operation r
 
 When in `Shutter` remote control, holding focus (button B) then release (button A) will engage shutter lock, holding the shutter open until a button is pressed.
 
+### Bluetooth
+
+The Bluetooth options live under `Settings->Bluetooth`.
+`TX Power` has moved there from the top level of `Settings`.
+
+`Scan mode` sets how hard the radio listens while `Scan` is looking for
+cameras.
+`Full` is the default and spots a camera fastest.
+`Balanced` and `Low` listen less of the time, which is easier on the battery
+but can take longer to find a camera.
+
+`Scan timeout` ends a scan by itself after 30, 60 or 120 seconds.
+The default is `Never`, which keeps scanning until you leave the page.
+When a scan does end on its own, the `Scan` page shows a `Scan finished` notice
+with a `Rescan` button.
+
+Pairing with a saved camera always scans at full duty, so neither setting slows
+down `Connect`.
+
 ### Themes
 
 A few basic themes are included, to change:

--- a/include/FurbleSettings.h
+++ b/include/FurbleSettings.h
@@ -26,6 +26,8 @@ class Settings {
     FAUXNY,
     TOUCH_CALIBRATION,
     AUTOCONNECT,
+    SCAN_MODE,
+    SCAN_TIMEOUT,
   } type_t;
 
   typedef struct {
@@ -145,6 +147,14 @@ struct Settings::storage_type<Settings::TOUCH_CALIBRATION> {
 template <>
 struct Settings::storage_type<Settings::AUTOCONNECT> {
   using type = bool;
+};
+template <>
+struct Settings::storage_type<Settings::SCAN_MODE> {
+  using type = uint8_t;
+};
+template <>
+struct Settings::storage_type<Settings::SCAN_TIMEOUT> {
+  using type = uint32_t;
 };
 
 }  // namespace Furble

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -1,6 +1,7 @@
 #ifndef FURBLE_UI_H
 #define FURBLE_UI_H
 
+#include <array>
 #include <initializer_list>
 #include <mutex>
 #include <unordered_map>
@@ -178,8 +179,14 @@ class UI {
   static constexpr const char *m_GPSStr = "GPS";
   static constexpr const char *m_IntervalometerStr = "Timer";
   static constexpr const char *m_ThemeStr = "Theme";
-  static constexpr const char *m_TransmitPowerStr = "TX Power";
+  static constexpr const char *m_BluetoothStr = "Bluetooth";
   static constexpr const char *m_AboutStr = "About";
+
+  // settings->bluetooth
+  static constexpr const char *m_TransmitPowerStr = "TX Power";
+
+  /** Scan timeout roller values, in seconds, zero is no timeout. */
+  static constexpr std::array<uint32_t, 4> m_ScanTimeout = {0, 30, 60, 120};
 
   // settings->gps
   static constexpr const char *m_GPSDataStr = "GPS Data";
@@ -205,6 +212,9 @@ class UI {
 
   LV_ATTRIBUTE_MEM_ALIGN void *m_Buffer1;
   LV_ATTRIBUTE_MEM_ALIGN void *m_Buffer2;
+
+  /** 'Scan finished' notice on the Scan page, hidden while scanning. */
+  static lv_obj_t *m_ScanFinished;
 
   static lv_timer_t *m_ConnectTimer;
   static lv_timer_t *m_IntervalPageRefresh;
@@ -316,6 +326,9 @@ class UI {
   /** Add the 'Scan' menu entry. */
   void addScanMenu(void);
 
+  /** Clear the 'Scan' page and start a discovery scan. */
+  static void startScan(void);
+
   /** Add the 'Delete' menu entry. */
   void addDeleteMenu(void);
 
@@ -339,6 +352,9 @@ class UI {
   void addThemeMenu(const menu_t &parent);
 
   void addTransmitPowerMenu(const menu_t &parent);
+
+  /** Add the 'Bluetooth' menu entry. */
+  void addBluetoothMenu(const menu_t &parent);
 
   void addAboutMenu(const menu_t &parent);
 

--- a/lib/furble/Scan.cpp
+++ b/lib/furble/Scan.cpp
@@ -16,11 +16,26 @@ Scan &Scan::getInstance(void) {
 
     instance.m_Scan = NimBLEDevice::getScan();
     instance.m_Scan->setActiveScan(true);
-    instance.m_Scan->setInterval(6553);
-    instance.m_Scan->setWindow(6553);
+    instance.applyMode(instance.m_Mode);
   }
 
   return instance;
+}
+
+void Scan::applyMode(Mode mode) {
+  const auto &duty = m_Duty[static_cast<size_t>(mode)];
+
+  // esp-nimble-cpp takes milliseconds and converts to 0.625ms units internally
+  m_Scan->setInterval(duty.interval);
+  m_Scan->setWindow(duty.window);
+}
+
+void Scan::setMode(Mode mode) {
+  m_Mode = mode;
+}
+
+void Scan::setTimeout(uint32_t timeout) {
+  m_Timeout = timeout;
 }
 
 /**
@@ -35,21 +50,43 @@ void Scan::onResult(const NimBLEAdvertisedDevice *pDevice) {
   }
 };
 
-void Scan::start(std::function<void(void *)> scanCallback, void *scanPrivateData) {
+/**
+ * BLE scan end callback.
+ */
+void Scan::onScanEnd(const NimBLEScanResults &, int reason) {
+  ESP_LOGI(LOG_TAG, "Scan ended, reason %d", reason);
+  if (m_ScanEndCallback != nullptr) {
+    (m_ScanEndCallback)(m_ScanResultPrivateData);
+  }
+};
+
+void Scan::start(std::function<void(void *)> scanCallback,
+                 void *scanPrivateData,
+                 std::function<void(void *)> scanEndCallback) {
   m_Server->start();
   m_Scan->setScanCallbacks(this);
 
   m_ScanResultCallback = scanCallback;
+  m_ScanEndCallback = scanEndCallback;
   m_ScanResultPrivateData = scanPrivateData;
-  m_Scan->start(0, false);
+
+  // apply the preset here so a settings change takes effect without a restart
+  applyMode(m_Mode);
+  m_Scan->start(m_Timeout * 1000, false);
 }
 
 void Scan::start(NimBLEScanCallbacks *pScanCallbacks, uint32_t duration) {
+  // pairing and reconnect ignore the user preset, a low duty cycle here turns a
+  // fast reconnect into a timeout
+  applyMode(Mode::FULL);
+
   m_Scan->setScanCallbacks(pScanCallbacks);
   m_Scan->start(duration, false);
 }
 
 void Scan::stop(void) {
+  // clear first, NimBLEScan::stop() invokes onScanEnd()
+  m_ScanEndCallback = nullptr;
   m_Scan->stop();
   m_ScanResultPrivateData = nullptr;
   m_ScanResultCallback = nullptr;

--- a/lib/furble/Scan.h
+++ b/lib/furble/Scan.h
@@ -1,6 +1,7 @@
 #ifndef SCAN_H
 #define SCAN_H
 
+#include <array>
 #include <vector>
 
 #include <NimBLEScan.h>
@@ -20,6 +21,17 @@ namespace Furble {
  */
 class Scan: public NimBLEScanCallbacks {
  public:
+  /**
+   * Scan duty cycle presets.
+   */
+  enum class Mode : uint8_t {
+    FULL = 0,      // 100 percent duty
+    BALANCED = 1,  // 25 percent duty
+    LOW = 2,       // 5 percent duty
+  };
+
+  static constexpr size_t MODE_COUNT = 3;
+
   static Scan &getInstance(void);
 
   Scan(Scan const &) = delete;
@@ -28,13 +40,30 @@ class Scan: public NimBLEScanCallbacks {
   Scan &operator=(Scan &&) = delete;
 
   /**
+   * Set the duty cycle preset, applied on the next discovery scan.
+   */
+  void setMode(Mode mode);
+
+  /**
+   * Set the discovery scan timeout in seconds, zero scans until stopped.
+   */
+  void setTimeout(uint32_t timeout);
+
+  /**
    * Start the scan for BLE advertisements with a callback function when a
    * matching reseult is encountered.
+   *
+   * The optional end callback fires when the scan stops by itself, it does not
+   * fire on stop().
    */
-  void start(std::function<void(void *)> scanCallback, void *scanResultPrivateData);
+  void start(std::function<void(void *)> scanCallback,
+             void *scanResultPrivateData,
+             std::function<void(void *)> scanEndCallback = nullptr);
 
   /**
    * Start scanning with a custom callback system.
+   *
+   * This is the pairing and reconnect path, it always scans at full duty.
    */
   void start(NimBLEScanCallbacks *pScanCallbacks, uint32_t duration);
 
@@ -55,15 +84,39 @@ class Scan: public NimBLEScanCallbacks {
 
   void onResult(const NimBLEAdvertisedDevice *pDevice) override;
 
+  void onScanEnd(const NimBLEScanResults &results, int reason) override;
+
  private:
   Scan() {};
 
+  /** Scan interval and window, both in milliseconds. */
+  typedef struct {
+    uint16_t interval;
+    uint16_t window;
+  } duty_t;
+
   static constexpr uint16_t HID_GENERIC_REMOTE = 0x180;
+
+  static constexpr std::array<duty_t, MODE_COUNT> m_Duty = {
+      {
+       {6553, 6553},  // FULL
+          {120, 30},     // BALANCED
+          {1000, 50},    // LOW
+      }
+  };
+
+  /**
+   * Apply a duty cycle preset to the scanner.
+   */
+  void applyMode(Mode mode);
 
   NimBLEServer *m_Server = nullptr;
   NimBLEScan *m_Scan = nullptr;
   std::function<void(void *)> m_ScanResultCallback;
+  std::function<void(void *)> m_ScanEndCallback;
   void *m_ScanResultPrivateData = nullptr;
+  Mode m_Mode = Mode::FULL;
+  uint32_t m_Timeout = 0;
 };
 
 }  // namespace Furble

--- a/src/FurbleSettings.cpp
+++ b/src/FurbleSettings.cpp
@@ -21,6 +21,8 @@ const std::unordered_map<Settings::type_t, Settings::setting_t> Settings::m_Sett
     {FAUXNY,            {FAUXNY, "FauxNY", "fauxNY", FURBLE_STR}                       },
     {TOUCH_CALIBRATION, {TOUCH_CALIBRATION, "Touch Calibration", "t_calib", FURBLE_STR}},
     {AUTOCONNECT,       {AUTOCONNECT, "Auto-Connect", "autoconnect", FURBLE_STR}       },
+    {SCAN_MODE,         {SCAN_MODE, "Scan Mode", "scan_mode", FURBLE_STR}              },
+    {SCAN_TIMEOUT,      {SCAN_TIMEOUT, "Scan Timeout", "scan_timeout", FURBLE_STR}     },
 };
 
 const Settings::setting_t &Settings::get(type_t type) {
@@ -194,6 +196,7 @@ void Settings::init(void) {
           save<std::string>(setting.type, "Default");
           break;
         case TX_POWER:
+        case SCAN_MODE:
           save<uint8_t>(setting.type, 0);
           break;
         case INTERVAL:
@@ -215,6 +218,9 @@ void Settings::init(void) {
           break;
         case GPS_BAUD:
           save<uint32_t>(setting.type, BAUD_9600);
+          break;
+        case SCAN_TIMEOUT:
+          save<uint32_t>(setting.type, 0);
           break;
         case TOUCH_CALIBRATION:
         {

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -2081,24 +2081,42 @@ void UI::addTransmitPowerMenu(const menu_t &parent) {
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }
 
+/**
+ * Add a labelled roller row to a menu page.
+ *
+ * The row is sized to its content so the page keeps flowing, a full height row
+ * pushes later rows off screen and stops the page scrolling. The roller is
+ * flagged to scroll itself into view, which is the only way the page scrolls
+ * under encoder navigation.
+ */
+static lv_obj_t *addRollerItem(lv_obj_t *page, const char *text, const char *options) {
+  lv_obj_t *cont = lv_menu_cont_create(page);
+  lv_obj_set_size(cont, LV_PCT(100), LV_SIZE_CONTENT);
+  lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
+
+  lv_obj_t *label = lv_label_create(cont);
+  lv_label_set_text(label, text);
+  lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+  lv_obj_set_width(label, LV_PCT(100));
+
+  lv_obj_t *roller = lv_roller_create(cont);
+  lv_obj_set_width(roller, LV_PCT(90));
+  lv_roller_set_options(roller, options, LV_ROLLER_MODE_INFINITE);
+  lv_roller_set_visible_row_count(roller, 2);
+  lv_obj_add_flag(roller, LV_OBJ_FLAG_SCROLL_ON_FOCUS);
+
+  return roller;
+}
+
 void UI::addBluetoothMenu(const menu_t &parent) {
   menu_t &menu = addMenu(m_BluetoothStr, &icon_settings_remote, true, parent);
+
+  lv_obj_set_flex_flow(menu.page, LV_FLEX_FLOW_COLUMN);
 
   addTransmitPowerMenu(menu);
 
   // scan duty cycle preset
-  lv_obj_t *modeCont = lv_menu_cont_create(menu.page);
-  lv_obj_set_flex_flow(modeCont, LV_FLEX_FLOW_COLUMN);
-
-  lv_obj_t *modeLabel = lv_label_create(modeCont);
-  lv_label_set_text(modeLabel, "Scan mode");
-  lv_label_set_long_mode(modeLabel, LV_LABEL_LONG_SCROLL_CIRCULAR);
-  lv_obj_set_width(modeLabel, LV_PCT(100));
-
-  lv_obj_t *modeRoller = lv_roller_create(modeCont);
-  lv_obj_set_width(modeRoller, LV_PCT(90));
-  lv_roller_set_options(modeRoller, "Full\nBalanced\nLow", LV_ROLLER_MODE_INFINITE);
-  lv_roller_set_visible_row_count(modeRoller, 2);
+  lv_obj_t *modeRoller = addRollerItem(menu.page, "Scan mode", "Full\nBalanced\nLow");
   lv_roller_set_selected(modeRoller, Settings::load<Settings::SCAN_MODE>(), LV_ANIM_OFF);
 
   lv_obj_add_event_cb(
@@ -2111,19 +2129,8 @@ void UI::addBluetoothMenu(const menu_t &parent) {
       LV_EVENT_VALUE_CHANGED, NULL);
 
   // scan timeout
-  lv_obj_t *timeoutCont = lv_menu_cont_create(menu.page);
-  lv_obj_set_flex_flow(timeoutCont, LV_FLEX_FLOW_COLUMN);
-
-  lv_obj_t *timeoutLabel = lv_label_create(timeoutCont);
-  lv_label_set_text(timeoutLabel, "Scan timeout");
-  lv_label_set_long_mode(timeoutLabel, LV_LABEL_LONG_SCROLL_CIRCULAR);
-  lv_obj_set_width(timeoutLabel, LV_PCT(100));
-
-  lv_obj_t *timeoutRoller = lv_roller_create(timeoutCont);
-  lv_obj_set_width(timeoutRoller, LV_PCT(90));
-  lv_roller_set_options(timeoutRoller, "Never\n30 secs\n60 secs\n120 secs",
-                        LV_ROLLER_MODE_INFINITE);
-  lv_roller_set_visible_row_count(timeoutRoller, 2);
+  lv_obj_t *timeoutRoller =
+      addRollerItem(menu.page, "Scan timeout", "Never\n30 secs\n60 secs\n120 secs");
 
   uint32_t timeout = Settings::load<Settings::SCAN_TIMEOUT>();
   auto it = std::find(m_ScanTimeout.begin(), m_ScanTimeout.end(), timeout);

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -43,6 +43,8 @@ std::mutex UI::m_Mutex;
 
 UI::ConnectContext_t UI::m_ConnectContext;
 
+lv_obj_t *UI::m_ScanFinished;
+
 lv_timer_t *UI::m_ConnectTimer;
 
 lv_timer_t *UI::m_IntervalPageRefresh;
@@ -67,8 +69,9 @@ std::unordered_map<const char *, UI::menu_t> UI::m_Menu = {
     {m_IntervalWaitStr,      {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_DisplayStr,           {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_ThemeStr,             {nullptr, nullptr, nullptr, nullptr, {0, 1}}},
-    {m_TransmitPowerStr,     {nullptr, nullptr, nullptr, nullptr, {1, 1}}},
+    {m_BluetoothStr,         {nullptr, nullptr, nullptr, nullptr, {1, 1}}},
     {m_AboutStr,             {nullptr, nullptr, nullptr, nullptr, {2, 1}}},
+    {m_TransmitPowerStr,     {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_RemoteShutter,        {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_RemoteInterval,       {nullptr, nullptr, nullptr, nullptr, {1, 0}}},
     {m_RemoteDisconnect,     {nullptr, nullptr, nullptr, nullptr, {2, 0}}},
@@ -926,27 +929,7 @@ void UI::addMainMenu(void) {
           }
         } else if (page == m_Menu.at(m_DeleteStr).page) {
         } else if (page == m_Menu.at(m_ScanStr).page) {
-          menu_t &menu = m_Menu.at(m_ScanStr);
-          lv_obj_clean(menu.page);
-          CameraList::clear();
-
-          if (Settings::load<Settings::FAUXNY>()) {
-            CameraList::addFauxNY();
-            updateItems(menu);
-          }
-
-          scan.clear();
-          scan.start(
-              [](void *param) {
-                auto *menu = static_cast<menu_t *>(param);
-                // Can be called asychronously from NimBLE scan thread,
-                m_Mutex.lock();
-                updateItems(*menu);
-                m_Mutex.unlock();
-              },
-              &menu);
-
-          m_ConnectContext.menuName = m_ScanStr;
+          startScan();
         } else if (page == m_Menu.at(m_SettingsStr).page) {
         } else if (page == m_Menu.at(m_ConnectStr).page) {
           // ensure menu control
@@ -1489,6 +1472,65 @@ void UI::addScanMenu(void) {
   menu_t &menu = addMenu(m_ScanStr, &icon_add_a_photo);
 
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
+}
+
+void UI::startScan(void) {
+  menu_t &menu = m_Menu.at(m_ScanStr);
+  auto &scan = Scan::getInstance();
+
+  lv_obj_clean(menu.page);
+  CameraList::clear();
+
+  // hidden until the scan ends by itself, a finite scan that ends silently
+  // looks like a hang
+  m_ScanFinished = lv_menu_cont_create(menu.page);
+  lv_obj_set_flex_flow(m_ScanFinished, LV_FLEX_FLOW_COLUMN);
+  lv_obj_add_flag(m_ScanFinished, LV_OBJ_FLAG_HIDDEN);
+
+  lv_obj_t *label = lv_label_create(m_ScanFinished);
+  lv_label_set_text(label, "Scan finished");
+  lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+  lv_obj_set_width(label, LV_PCT(100));
+
+  lv_obj_t *rescan = lv_button_create(m_ScanFinished);
+  lv_obj_t *rescanLabel = lv_label_create(rescan);
+  lv_label_set_text(rescanLabel, "Rescan");
+  lv_group_add_obj(menu.group, rescan);
+
+  lv_obj_add_event_cb(
+      rescan,
+      [](lv_event_t *) {
+        // deferred, the restart deletes the button we are called from
+        lv_async_call([](void *) { startScan(); }, NULL);
+      },
+      LV_EVENT_CLICKED, NULL);
+
+  if (Settings::load<Settings::FAUXNY>()) {
+    CameraList::addFauxNY();
+    updateItems(menu);
+  }
+
+  scan.setMode(static_cast<Scan::Mode>(Settings::load<Settings::SCAN_MODE>()));
+  scan.setTimeout(Settings::load<Settings::SCAN_TIMEOUT>());
+
+  scan.clear();
+  scan.start(
+      [](void *param) {
+        auto *menu = static_cast<menu_t *>(param);
+        // Can be called asychronously from NimBLE scan thread,
+        m_Mutex.lock();
+        updateItems(*menu);
+        m_Mutex.unlock();
+      },
+      &menu,
+      [](void *) {
+        // Can be called asychronously from NimBLE scan thread,
+        m_Mutex.lock();
+        lv_obj_remove_flag(m_ScanFinished, LV_OBJ_FLAG_HIDDEN);
+        m_Mutex.unlock();
+      });
+
+  m_ConnectContext.menuName = m_ScanStr;
 }
 
 void UI::refreshDelete(void) {
@@ -2039,6 +2081,67 @@ void UI::addTransmitPowerMenu(const menu_t &parent) {
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }
 
+void UI::addBluetoothMenu(const menu_t &parent) {
+  menu_t &menu = addMenu(m_BluetoothStr, &icon_settings_remote, true, parent);
+
+  addTransmitPowerMenu(menu);
+
+  // scan duty cycle preset
+  lv_obj_t *modeCont = lv_menu_cont_create(menu.page);
+  lv_obj_set_flex_flow(modeCont, LV_FLEX_FLOW_COLUMN);
+
+  lv_obj_t *modeLabel = lv_label_create(modeCont);
+  lv_label_set_text(modeLabel, "Scan mode");
+  lv_label_set_long_mode(modeLabel, LV_LABEL_LONG_SCROLL_CIRCULAR);
+  lv_obj_set_width(modeLabel, LV_PCT(100));
+
+  lv_obj_t *modeRoller = lv_roller_create(modeCont);
+  lv_obj_set_width(modeRoller, LV_PCT(90));
+  lv_roller_set_options(modeRoller, "Full\nBalanced\nLow", LV_ROLLER_MODE_INFINITE);
+  lv_roller_set_visible_row_count(modeRoller, 2);
+  lv_roller_set_selected(modeRoller, Settings::load<Settings::SCAN_MODE>(), LV_ANIM_OFF);
+
+  lv_obj_add_event_cb(
+      modeRoller,
+      [](lv_event_t *e) {
+        auto *roller = static_cast<lv_obj_t *>(lv_event_get_target(e));
+        uint8_t mode = lv_roller_get_selected(roller);
+        Settings::save<Settings::SCAN_MODE>(mode);
+      },
+      LV_EVENT_VALUE_CHANGED, NULL);
+
+  // scan timeout
+  lv_obj_t *timeoutCont = lv_menu_cont_create(menu.page);
+  lv_obj_set_flex_flow(timeoutCont, LV_FLEX_FLOW_COLUMN);
+
+  lv_obj_t *timeoutLabel = lv_label_create(timeoutCont);
+  lv_label_set_text(timeoutLabel, "Scan timeout");
+  lv_label_set_long_mode(timeoutLabel, LV_LABEL_LONG_SCROLL_CIRCULAR);
+  lv_obj_set_width(timeoutLabel, LV_PCT(100));
+
+  lv_obj_t *timeoutRoller = lv_roller_create(timeoutCont);
+  lv_obj_set_width(timeoutRoller, LV_PCT(90));
+  lv_roller_set_options(timeoutRoller, "Never\n30 secs\n60 secs\n120 secs",
+                        LV_ROLLER_MODE_INFINITE);
+  lv_roller_set_visible_row_count(timeoutRoller, 2);
+
+  uint32_t timeout = Settings::load<Settings::SCAN_TIMEOUT>();
+  auto it = std::find(m_ScanTimeout.begin(), m_ScanTimeout.end(), timeout);
+  if (it != m_ScanTimeout.end()) {
+    lv_roller_set_selected(timeoutRoller, std::distance(m_ScanTimeout.begin(), it), LV_ANIM_OFF);
+  }
+
+  lv_obj_add_event_cb(
+      timeoutRoller,
+      [](lv_event_t *e) {
+        auto *roller = static_cast<lv_obj_t *>(lv_event_get_target(e));
+        Settings::save<Settings::SCAN_TIMEOUT>(m_ScanTimeout[lv_roller_get_selected(roller)]);
+      },
+      LV_EVENT_VALUE_CHANGED, NULL);
+
+  lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
+}
+
 void UI::addAboutMenu(const menu_t &parent) {
   menu_t &menu = addMenu(m_AboutStr, &icon_info, true, parent);
   lv_obj_t *cont = lv_menu_cont_create(menu.page);
@@ -2075,7 +2178,7 @@ void UI::addSettingsMenu(void) {
   addGPSMenu(menu);
   addIntervalometerMenu(menu);
   addThemeMenu(menu);
-  addTransmitPowerMenu(menu);
+  addBluetoothMenu(menu);
   addAboutMenu(menu);
 
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);


### PR DESCRIPTION
Closes #293.

Scanning for cameras runs the radio at 100 percent duty and never stops on its own. If you leave the Scan page open, or walk away mid-scan, the radio keeps burning battery for no benefit.

This adds three scan duty cycle presets. Full is the current 6553 ms interval and window. Balanced uses a 120 ms interval with a 30 ms window, and Low uses a 1000 ms interval with a 50 ms window. It also adds an optional scan timeout, after which the scan stops and the Scan page shows a Scan finished notice with a Rescan button. Both settings default to today's behavior. The pairing and reconnect path always scans at full duty, because FujifilmSecure and Nikon wait up to 60 seconds for a saved camera to advertise and a low duty cycle there would turn a fast reconnect into a timeout.

Both settings live in a new Settings > Bluetooth page. TX Power moves there from the Settings root, which changes muscle memory but frees a grid slot on Core and Core2.

Build verified on all five environments. Not hardware tested yet. The Fujifilm advertising interval has not been measured, so the Balanced and Low numbers may need tuning. Sony, Nikon, Canon and Ricoh are untested; Nikon shares the pairing rescan path with FujifilmSecure, so a Fujifilm reconnect test is the closest available evidence for it.

Plan document: https://github.com/MaxRink/furble/blob/plans/plans/08-scan-tuning.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)