### PR TITLE
Expand About page and add a Diagnostics menu

### DIFF
--- a/include/FurblePlatform.h
+++ b/include/FurblePlatform.h
@@ -39,6 +39,18 @@ class Platform {
     bool charging;
   } battery_t;
 
+  /**
+   * Power management configuration.
+   *
+   * The frequencies are the configured ceiling and floor, not a measurement of
+   * what the CPU is running at right now.
+   */
+  typedef struct {
+    uint8_t max_freq_mhz;
+    uint8_t min_freq_mhz;
+    bool light_sleep_enable;
+  } pm_config_t;
+
   static Platform &getInstance();
 
   Platform(Platform const &) = delete;
@@ -85,6 +97,24 @@ class Platform {
    * Get the maximum CPU frequency in MHz.
    */
   uint8_t getCPUMaxFreq(void) const;
+
+  /**
+   * Read back the live power management configuration.
+   */
+  pm_config_t getPMConfig(void);
+
+  /**
+   * Dump the power management locks to the console.
+   *
+   * The output goes to the serial console, not the display. Hold times are only
+   * reported with CONFIG_PM_PROFILING, which is off in the shipping build.
+   */
+  void dumpPMLocks(void);
+
+  /**
+   * Is tickless idle compiled in?
+   */
+  static bool hasTicklessIdle(void);
 
   /**
    * Get the battery measurements supported by this board.

--- a/include/FurblePlatform.h
+++ b/include/FurblePlatform.h
@@ -4,6 +4,7 @@
 #include <array>
 
 #include <esp_err.h>
+#include <esp_log.h>
 
 #include <M5PM1.h>
 
@@ -15,6 +16,28 @@ class Platform {
 
   /** Default maximum CPU frequency in MHz. */
   static constexpr uint8_t CPU_MAX_FREQ_DEFAULT_MHZ = 160;
+
+  /**
+   * Battery measurements available on this board.
+   */
+  typedef struct {
+    bool level;
+    bool voltage;
+    bool current;
+    bool charging;
+  } battery_caps_t;
+
+  /**
+   * Battery measurement sample.
+   *
+   * Only fields flagged in battery_caps_t are meaningful.
+   */
+  typedef struct {
+    uint8_t level;     // percent
+    uint16_t voltage;  // millivolts
+    int32_t current;   // milliamps, positive when charging
+    bool charging;
+  } battery_t;
 
   static Platform &getInstance();
 
@@ -63,6 +86,26 @@ class Platform {
    */
   uint8_t getCPUMaxFreq(void) const;
 
+  /**
+   * Get the battery measurements supported by this board.
+   */
+  const battery_caps_t &getBatteryCaps(void);
+
+  /**
+   * Read the battery, unsupported measurements are returned as zero.
+   */
+  battery_t readBattery(void);
+
+  /**
+   * Get the battery capacity in mAh, zero if unknown.
+   */
+  uint16_t getBatteryCapacity(void);
+
+  /**
+   * Get the count of PMIC accesses which failed after a retry.
+   */
+  uint32_t getBatteryFailCount(void);
+
  private:
   Platform() {};
 
@@ -81,6 +124,36 @@ class Platform {
   // Power button click streak threshold
   const uint8_t PWR_CLICK_THRESHOLD_MS = 20;
 
+  /**
+   * Perform an M5PM1 access, retrying once on failure.
+   *
+   * The M5PM1 sleeps after an I2C idle period, the vendor documents that the
+   * first access after that only wakes the device and fails.
+   */
+  template <typename T>
+  bool m5pm1Access(T &&access) {
+    if (access() == M5PM1_OK) {
+      return true;
+    }
+
+    m_M5PM1RetryCount++;
+    ESP_LOGD("platform", "M5PM1 access failed, retrying (%lu)", m_M5PM1RetryCount);
+
+    if (access() == M5PM1_OK) {
+      return true;
+    }
+
+    m_M5PM1FailCount++;
+    ESP_LOGW("platform", "M5PM1 access failed after retry (%lu)", m_M5PM1FailCount);
+
+    return false;
+  }
+
+  /**
+   * Record which battery measurements this board supports.
+   */
+  void initBattery(void);
+
   M5PM1 m_M5PM1;
 
   bool m_Init = false;
@@ -89,6 +162,11 @@ class Platform {
   uint8_t m_CPUMaxFreqMHz = CPU_MAX_FREQ_DEFAULT_MHZ;
   uint8_t m_PMICClickCount = 0;
   uint32_t m_PMICClickTime = 0;
+
+  battery_caps_t m_BatteryCaps = {false, false, false, false};
+  uint16_t m_BatteryCapacity = 0;
+  uint32_t m_M5PM1RetryCount = 0;
+  uint32_t m_M5PM1FailCount = 0;
 };
 }  // namespace Furble
 

--- a/include/FurblePlatform.h
+++ b/include/FurblePlatform.h
@@ -1,11 +1,21 @@
 #ifndef FURBLE_PLATFORM_H
 #define FURBLE_PLATFORM_H
 
+#include <array>
+
+#include <esp_err.h>
+
 #include <M5PM1.h>
 
 namespace Furble {
 class Platform {
  public:
+  /** Selectable maximum CPU frequencies in MHz. */
+  static constexpr std::array<uint8_t, 3> CPU_MAX_FREQ_MHZ = {80, 160, 240};
+
+  /** Default maximum CPU frequency in MHz. */
+  static constexpr uint8_t CPU_MAX_FREQ_DEFAULT_MHZ = 160;
+
   static Platform &getInstance();
 
   Platform(Platform const &) = delete;
@@ -40,10 +50,32 @@ class Platform {
    */
   void setSleep(bool enable);
 
+  /**
+   * Set the maximum CPU frequency in MHz.
+   *
+   * Unsupported values fall back to the default. Use getCPUMaxFreq() to read
+   * back what was actually applied.
+   */
+  void setCPUMaxFreq(uint8_t mhz);
+
+  /**
+   * Get the maximum CPU frequency in MHz.
+   */
+  uint8_t getCPUMaxFreq(void) const;
+
  private:
   Platform() {};
 
-  const int CPU_MAX_FREQ_MHZ = 160;
+  /**
+   * Apply the power management configuration.
+   */
+  esp_err_t configurePM(uint8_t max_freq_mhz, bool sleep);
+
+  /**
+   * Is the frequency one we are prepared to ask for?
+   */
+  static bool isCPUMaxFreqValid(uint8_t mhz);
+
   const int CPU_MIN_FREQ_MHZ = 40;
 
   // Power button click streak threshold
@@ -53,6 +85,8 @@ class Platform {
 
   bool m_Init = false;
   bool m_PMICHack = false;
+  bool m_Sleep = true;
+  uint8_t m_CPUMaxFreqMHz = CPU_MAX_FREQ_DEFAULT_MHZ;
   uint8_t m_PMICClickCount = 0;
   uint32_t m_PMICClickTime = 0;
 };

--- a/include/FurbleSettings.h
+++ b/include/FurbleSettings.h
@@ -27,6 +27,7 @@ class Settings {
     TOUCH_CALIBRATION,
     AUTOCONNECT,
     CPU_FREQ,
+    BATT_STYLE,
   } type_t;
 
   typedef struct {
@@ -59,6 +60,13 @@ class Settings {
     const char *key;
     const char *nvs_namespace;
   } setting_t;
+
+  /** Battery status display styles. */
+  typedef enum {
+    BATT_STYLE_ICON = 0,
+    BATT_STYLE_PERCENT = 1,
+    BATT_STYLE_BOTH = 2,
+  } batt_style_t;
 
   static constexpr uint32_t BAUD_9600 = 9600;
   static constexpr uint32_t BAUD_115200 = 115200;
@@ -152,6 +160,10 @@ struct Settings::storage_type<Settings::AUTOCONNECT> {
 };
 template <>
 struct Settings::storage_type<Settings::CPU_FREQ> {
+  using type = uint8_t;
+};
+template <>
+struct Settings::storage_type<Settings::BATT_STYLE> {
   using type = uint8_t;
 };
 

--- a/include/FurbleSettings.h
+++ b/include/FurbleSettings.h
@@ -26,6 +26,7 @@ class Settings {
     FAUXNY,
     TOUCH_CALIBRATION,
     AUTOCONNECT,
+    CPU_FREQ,
   } type_t;
 
   typedef struct {
@@ -61,6 +62,9 @@ class Settings {
 
   static constexpr uint32_t BAUD_9600 = 9600;
   static constexpr uint32_t BAUD_115200 = 115200;
+
+  /** Default maximum CPU frequency in MHz, matches Platform. */
+  static constexpr uint8_t CPU_FREQ_DEFAULT = 160;
 
   static void init(void);
 
@@ -145,6 +149,10 @@ struct Settings::storage_type<Settings::TOUCH_CALIBRATION> {
 template <>
 struct Settings::storage_type<Settings::AUTOCONNECT> {
   using type = bool;
+};
+template <>
+struct Settings::storage_type<Settings::CPU_FREQ> {
+  using type = uint8_t;
 };
 
 }  // namespace Furble

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -85,6 +85,16 @@ class UI {
     float meanCurrent;
   } status_t;
 
+  typedef struct {
+    // labels refreshed while a diagnostics page is open
+    lv_obj_t *aboutUptime;
+    lv_obj_t *aboutHeap;
+    lv_obj_t *deviceUptime;
+    lv_obj_t *deviceHeap;
+    lv_obj_t *powerFrequency;
+    lv_obj_t *powerSleep;
+  } diagnostics_t;
+
   class Intervalometer {
    public:
     class Spinner {
@@ -192,9 +202,14 @@ class UI {
   static constexpr const char *m_TransmitPowerStr = "TX Power";
   static constexpr const char *m_AboutStr = "About";
   static constexpr const char *m_PowerStr = "Power";
+  static constexpr const char *m_DiagnosticsStr = "Diagnostics";
 
   // settings->power
   static constexpr const char *m_BatteryStr = "Battery";
+
+  // settings->diagnostics
+  static constexpr const char *m_DeviceInfoStr = "Device info";
+  static constexpr const char *m_PowerStateStr = "Power state";
 
   // settings->gps
   static constexpr const char *m_GPSDataStr = "GPS Data";
@@ -229,11 +244,17 @@ class UI {
   lv_timer_t *m_InactivityTimer;
   lv_timer_t *m_IconTimer;
   lv_timer_t *m_BatteryTimer;
+  lv_timer_t *m_DiagnosticsTimer;
 
   const std::vector<int32_t> m_GridLayoutColDsc = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
                                                    LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
   const std::vector<int32_t> m_GridLayoutRowDsc = {LV_GRID_FR(1), LV_GRID_FR(1),
                                                    LV_GRID_TEMPLATE_LAST};
+
+  // the settings page holds more entries than the main menu, give it its own
+  // rows so the main menu keeps its layout
+  const std::vector<int32_t> m_SettingsGridLayoutRowDsc = {LV_GRID_FR(1), LV_GRID_FR(1),
+                                                           LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
 
   GPS &m_GPS;
 
@@ -265,6 +286,7 @@ class UI {
   Intervalometer m_Intervalometer;
 
   status_t m_Status;
+  diagnostics_t m_Diagnostics = {};
   bool m_FocusPressed = false;
   bool m_ShutterLock = false;
   uint32_t m_InactivityTimeout;
@@ -369,6 +391,24 @@ class UI {
   void addTransmitPowerMenu(const menu_t &parent);
 
   void addAboutMenu(const menu_t &parent);
+
+  /** Add the 'Diagnostics' menu entry. */
+  void addDiagnosticsMenu(const menu_t &parent);
+
+  /** Add the 'Device info' page. */
+  void addDeviceInfoMenu(const menu_t &parent);
+
+  /** Add the 'Power state' page. */
+  void addPowerStateMenu(const menu_t &parent);
+
+  /** Add a read only text row to a page container. */
+  static lv_obj_t *addInfoRow(lv_obj_t *cont);
+
+  /** Diagnostics refresh timer handler. */
+  static void diagnosticsUpdate(lv_timer_t *timer);
+
+  /** Describe the last reset reason. */
+  static const char *getResetReason(void);
 
   /** Add the 'Settings' menu entry. */
   void addSettingsMenu(void);

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -10,6 +10,7 @@
 #include "FurbleCalibrate.h"
 #include "FurbleControl.h"
 #include "FurbleGPS.h"
+#include "FurblePlatform.h"
 #include "FurbleSettings.h"
 #include "interval.h"
 
@@ -68,10 +69,20 @@ class UI {
     GPS *gps;
     lv_obj_t *gpsIcon;
     lv_obj_t *batteryIcon;
+    lv_obj_t *batteryLabel;
     lv_obj_t *reconnectIcon;
     lv_obj_t *gpsBaud;
     lv_obj_t *gpsData;
+    // battery page rows, NULL where the board cannot measure them
+    lv_obj_t *batteryLevel;
+    lv_obj_t *batteryVoltage;
+    lv_obj_t *batteryCurrent;
+    lv_obj_t *batteryCharging;
+    lv_obj_t *batteryRuntime;
     bool screenLocked;
+    // last battery sample and its smoothed current
+    Platform::battery_t battery;
+    float meanCurrent;
   } status_t;
 
   class Intervalometer {
@@ -182,6 +193,9 @@ class UI {
   static constexpr const char *m_AboutStr = "About";
   static constexpr const char *m_PowerStr = "Power";
 
+  // settings->power
+  static constexpr const char *m_BatteryStr = "Battery";
+
   // settings->gps
   static constexpr const char *m_GPSDataStr = "GPS Data";
 
@@ -214,6 +228,7 @@ class UI {
   lv_timer_t *m_IntervalTimer;
   lv_timer_t *m_InactivityTimer;
   lv_timer_t *m_IconTimer;
+  lv_timer_t *m_BatteryTimer;
 
   const std::vector<int32_t> m_GridLayoutColDsc = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
                                                    LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
@@ -339,6 +354,15 @@ class UI {
 
   /** Add the 'Power' menu entry. */
   void addPowerMenu(const menu_t &parent);
+
+  /** Add the 'Battery' page. */
+  void addBatteryMenu(const menu_t &parent);
+
+  /** Show the header battery icon and/or percent according to the setting. */
+  void setBatteryStyle(uint8_t style);
+
+  /** Battery sample timer handler. */
+  static void batteryUpdate(lv_timer_t *timer);
 
   void addThemeMenu(const menu_t &parent);
 

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -180,6 +180,7 @@ class UI {
   static constexpr const char *m_ThemeStr = "Theme";
   static constexpr const char *m_TransmitPowerStr = "TX Power";
   static constexpr const char *m_AboutStr = "About";
+  static constexpr const char *m_PowerStr = "Power";
 
   // settings->gps
   static constexpr const char *m_GPSDataStr = "GPS Data";
@@ -335,6 +336,9 @@ class UI {
   void addSpinnerPage(const menu_t &parent, const char *item, Intervalometer::Spinner &spinner);
 
   void addDisplayMenu(const menu_t &parent);
+
+  /** Add the 'Power' menu entry. */
+  void addPowerMenu(const menu_t &parent);
 
   void addThemeMenu(const menu_t &parent);
 

--- a/src/FurblePlatform.cpp
+++ b/src/FurblePlatform.cpp
@@ -111,6 +111,35 @@ uint8_t Platform::getCPUMaxFreq(void) const {
   return m_CPUMaxFreqMHz;
 }
 
+Platform::pm_config_t Platform::getPMConfig(void) {
+  esp_pm_config_t pm_config = {};
+
+  esp_err_t err = esp_pm_get_configuration(&pm_config);
+  if (err != ESP_OK) {
+    // fall back to the last configuration we asked for
+    ESP_LOGW(LOG_TAG, "Unable to read power management configuration (%s).", esp_err_to_name(err));
+    return {m_CPUMaxFreqMHz, static_cast<uint8_t>(CPU_MIN_FREQ_MHZ), m_Sleep};
+  }
+
+  return {static_cast<uint8_t>(pm_config.max_freq_mhz),
+          static_cast<uint8_t>(pm_config.min_freq_mhz), pm_config.light_sleep_enable};
+}
+
+void Platform::dumpPMLocks(void) {
+  esp_err_t err = esp_pm_dump_locks(stdout);
+  if (err != ESP_OK) {
+    ESP_LOGW(LOG_TAG, "Unable to dump power management locks (%s).", esp_err_to_name(err));
+  }
+}
+
+bool Platform::hasTicklessIdle(void) {
+#if defined(CONFIG_FREERTOS_USE_TICKLESS_IDLE)
+  return true;
+#else
+  return false;
+#endif
+}
+
 void Platform::powerOff(void) {
 #if defined(FURBLE_M5STICKS3)
   m_M5PM1.shutdown();

--- a/src/FurblePlatform.cpp
+++ b/src/FurblePlatform.cpp
@@ -1,9 +1,12 @@
+#include <algorithm>
+
 #include <esp_pm.h>
 
 #include <M5PM1.h>
 #include <M5Unified.h>
 
 #include "FurblePlatform.h"
+#include "FurbleTypes.h"
 
 namespace Furble {
 
@@ -62,13 +65,48 @@ uint8_t Platform::getPWRClickCount(void) {
   return count;
 }
 
-void Platform::setSleep(bool enable) {
+esp_err_t Platform::configurePM(uint8_t max_freq_mhz, bool sleep) {
   esp_pm_config_t pm_config = {
-      .max_freq_mhz = CPU_MAX_FREQ_MHZ,
+      .max_freq_mhz = max_freq_mhz,
       .min_freq_mhz = CPU_MIN_FREQ_MHZ,
-      .light_sleep_enable = enable,
+      .light_sleep_enable = sleep,
   };
-  ESP_ERROR_CHECK(esp_pm_configure(&pm_config));
+  return esp_pm_configure(&pm_config);
+}
+
+bool Platform::isCPUMaxFreqValid(uint8_t mhz) {
+  return std::find(CPU_MAX_FREQ_MHZ.begin(), CPU_MAX_FREQ_MHZ.end(), mhz) != CPU_MAX_FREQ_MHZ.end();
+}
+
+void Platform::setSleep(bool enable) {
+  m_Sleep = enable;
+  ESP_ERROR_CHECK(configurePM(m_CPUMaxFreqMHz, enable));
+}
+
+void Platform::setCPUMaxFreq(uint8_t mhz) {
+  uint8_t freq = mhz;
+
+  // NVS may hold anything, never hand an unvetted value to esp_pm_configure()
+  if (!isCPUMaxFreqValid(freq)) {
+    ESP_LOGW(LOG_TAG, "Unsupported CPU maximum frequency %dMHz, using %dMHz.", freq,
+             CPU_MAX_FREQ_DEFAULT_MHZ);
+    freq = CPU_MAX_FREQ_DEFAULT_MHZ;
+  }
+
+  // The board may still refuse the frequency, fall back rather than abort
+  esp_err_t err = configurePM(freq, m_Sleep);
+  if (err != ESP_OK) {
+    ESP_LOGW(LOG_TAG, "CPU maximum frequency %dMHz rejected (%s), using %dMHz.", freq,
+             esp_err_to_name(err), CPU_MAX_FREQ_DEFAULT_MHZ);
+    freq = CPU_MAX_FREQ_DEFAULT_MHZ;
+    ESP_ERROR_CHECK(configurePM(freq, m_Sleep));
+  }
+
+  m_CPUMaxFreqMHz = freq;
+}
+
+uint8_t Platform::getCPUMaxFreq(void) const {
+  return m_CPUMaxFreqMHz;
 }
 
 void Platform::powerOff(void) {

--- a/src/FurblePlatform.cpp
+++ b/src/FurblePlatform.cpp
@@ -41,6 +41,8 @@ Platform &Platform::getInstance(void) {
     instance.m_M5PM1.setDownloadLock(true);        // disable BtnPWR long-press enter download mode
 #endif
 
+    instance.initBattery();
+
     instance.m_Init = true;
   }
 
@@ -115,6 +117,112 @@ void Platform::powerOff(void) {
 #else
   M5.Power.powerOff();
 #endif
+}
+
+void Platform::initBattery(void) {
+  // capabilities follow the PMIC, capacities are from the vendor product pages
+  switch (M5.getBoard()) {
+    case m5::board_t::board_M5StickC:
+      // AXP192
+      m_BatteryCaps = {true, true, true, true};
+      m_BatteryCapacity = 95;
+      break;
+
+    case m5::board_t::board_M5StickCPlus:
+      // AXP192
+      m_BatteryCaps = {true, true, true, true};
+      m_BatteryCapacity = 120;
+      break;
+
+    case m5::board_t::board_M5StackCore2:
+    case m5::board_t::board_M5Tough:
+      // AXP192
+      m_BatteryCaps = {true, true, true, true};
+      m_BatteryCapacity = 390;
+      break;
+
+    case m5::board_t::board_M5StickS3:
+      // M5PM1, which has no battery current backend in M5Unified and no
+      // documented battery current register
+      m_BatteryCaps = {true, true, false, true};
+      m_BatteryCapacity = 250;
+      break;
+
+    case m5::board_t::board_M5StickCPlus2:
+      // no PMIC, battery voltage is read from an ADC divider
+      m_BatteryCaps = {true, true, false, false};
+      m_BatteryCapacity = 200;
+      break;
+
+    case m5::board_t::board_M5Stack:
+      // IP5306, coarse level only
+      m_BatteryCaps = {true, false, false, false};
+      m_BatteryCapacity = 0;
+      break;
+
+    default:
+      m_BatteryCaps = {true, false, false, false};
+      m_BatteryCapacity = 0;
+  }
+
+  ESP_LOGI("platform", "Battery: level=%u voltage=%u current=%u charging=%u capacity=%umAh",
+           m_BatteryCaps.level, m_BatteryCaps.voltage, m_BatteryCaps.current,
+           m_BatteryCaps.charging, m_BatteryCapacity);
+}
+
+const Platform::battery_caps_t &Platform::getBatteryCaps(void) {
+  return m_BatteryCaps;
+}
+
+uint16_t Platform::getBatteryCapacity(void) {
+  return m_BatteryCapacity;
+}
+
+uint32_t Platform::getBatteryFailCount(void) {
+  return m_M5PM1FailCount;
+}
+
+Platform::battery_t Platform::readBattery(void) {
+  battery_t battery = {0, 0, 0, false};
+
+  if (m_BatteryCaps.level) {
+    int32_t level = M5.Power.getBatteryLevel();
+    battery.level = (level > 0) ? level : 0;
+  }
+
+#if defined(FURBLE_M5STICKS3)
+  // the M5PM1 reports voltage and charge status, but no battery current
+  if (m_BatteryCaps.voltage) {
+    uint16_t mv = 0;
+    if (m5pm1Access([this, &mv]() { return m_M5PM1.readVbat(&mv); })) {
+      battery.voltage = mv;
+    }
+  }
+
+  if (m_BatteryCaps.charging) {
+    // charge status is on M5PM1 GPIO0, active low
+    uint8_t charging = 1;
+    if (m5pm1Access(
+            [this, &charging]() { return m_M5PM1.gpioGetInput(M5PM1_GPIO_NUM_0, &charging); })) {
+      battery.charging = (charging == 0);
+    }
+  }
+#else
+  if (m_BatteryCaps.voltage) {
+    int32_t mv = M5.Power.getBatteryVoltage();
+    battery.voltage = (mv > 0) ? mv : 0;
+  }
+
+  if (m_BatteryCaps.current) {
+    battery.current = M5.Power.getBatteryCurrent();
+  }
+
+  if (m_BatteryCaps.charging) {
+    battery.charging = (M5.Power.isCharging() == m5::Power_Class::is_charging_t::is_charging);
+  }
+#endif
+
+  return battery;
 }
 
 void Platform::update(void) {

--- a/src/FurbleSettings.cpp
+++ b/src/FurbleSettings.cpp
@@ -22,6 +22,7 @@ const std::unordered_map<Settings::type_t, Settings::setting_t> Settings::m_Sett
     {TOUCH_CALIBRATION, {TOUCH_CALIBRATION, "Touch Calibration", "t_calib", FURBLE_STR}},
     {AUTOCONNECT,       {AUTOCONNECT, "Auto-Connect", "autoconnect", FURBLE_STR}       },
     {CPU_FREQ,          {CPU_FREQ, "CPU Speed", "cpu_freq", FURBLE_STR}                },
+    {BATT_STYLE,        {BATT_STYLE, "Battery Style", "batt_style", FURBLE_STR}        },
 };
 
 const Settings::setting_t &Settings::get(type_t type) {
@@ -196,6 +197,9 @@ void Settings::init(void) {
           break;
         case TX_POWER:
           save<uint8_t>(setting.type, 0);
+          break;
+        case BATT_STYLE:
+          save<uint8_t>(setting.type, BATT_STYLE_ICON);
           break;
         case INTERVAL:
         {

--- a/src/FurbleSettings.cpp
+++ b/src/FurbleSettings.cpp
@@ -21,6 +21,7 @@ const std::unordered_map<Settings::type_t, Settings::setting_t> Settings::m_Sett
     {FAUXNY,            {FAUXNY, "FauxNY", "fauxNY", FURBLE_STR}                       },
     {TOUCH_CALIBRATION, {TOUCH_CALIBRATION, "Touch Calibration", "t_calib", FURBLE_STR}},
     {AUTOCONNECT,       {AUTOCONNECT, "Auto-Connect", "autoconnect", FURBLE_STR}       },
+    {CPU_FREQ,          {CPU_FREQ, "CPU Speed", "cpu_freq", FURBLE_STR}                },
 };
 
 const Settings::setting_t &Settings::get(type_t type) {
@@ -215,6 +216,9 @@ void Settings::init(void) {
           break;
         case GPS_BAUD:
           save<uint32_t>(setting.type, BAUD_9600);
+          break;
+        case CPU_FREQ:
+          save<uint8_t>(setting.type, CPU_FREQ_DEFAULT);
           break;
         case TOUCH_CALIBRATION:
         {

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -69,6 +69,7 @@ std::unordered_map<const char *, UI::menu_t> UI::m_Menu = {
     {m_ThemeStr,             {nullptr, nullptr, nullptr, nullptr, {0, 1}}},
     {m_TransmitPowerStr,     {nullptr, nullptr, nullptr, nullptr, {1, 1}}},
     {m_AboutStr,             {nullptr, nullptr, nullptr, nullptr, {2, 1}}},
+    {m_PowerStr,             {nullptr, nullptr, nullptr, nullptr, {3, 1}}},
     {m_RemoteShutter,        {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_RemoteInterval,       {nullptr, nullptr, nullptr, nullptr, {1, 0}}},
     {m_RemoteDisconnect,     {nullptr, nullptr, nullptr, nullptr, {2, 0}}},
@@ -1949,6 +1950,61 @@ void UI::addDisplayMenu(const menu_t &parent) {
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }
 
+void UI::addPowerMenu(const menu_t &parent) {
+  menu_t &menu = addMenu(m_PowerStr, &icon_power_settings_new, true, parent);
+  lv_obj_t *cont = lv_menu_cont_create(menu.page);
+  lv_obj_set_height(cont, LV_PCT(100));
+  lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+
+  // Add CPU maximum frequency control
+  lv_obj_t *label = lv_label_create(cont);
+  lv_label_set_text(label, "CPU speed");
+  lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+  lv_obj_set_width(label, LV_PCT(100));
+
+  const auto &frequencies = Platform::CPU_MAX_FREQ_MHZ;
+  std::string options;
+  for (const auto mhz : frequencies) {
+    if (!options.empty()) {
+      options += "\n";
+    }
+    options += std::to_string(mhz) + " MHz";
+  }
+
+  lv_obj_t *roller = lv_roller_create(cont);
+  lv_obj_set_width(roller, LV_PCT(90));
+  lv_roller_set_options(roller, options.c_str(), LV_ROLLER_MODE_INFINITE);
+  lv_roller_set_visible_row_count(roller, 2);
+
+  // The roller index is not the frequency, map it explicitly
+  // getCPUMaxFreq() only ever returns a listed frequency, so the find succeeds
+  auto &platform = Platform::getInstance();
+  uint32_t index =
+      std::distance(frequencies.begin(),
+                    std::find(frequencies.begin(), frequencies.end(), platform.getCPUMaxFreq()));
+  lv_roller_set_selected(roller, index, LV_ANIM_OFF);
+
+  lv_obj_add_event_cb(
+      roller,
+      [](lv_event_t *e) {
+        auto *roller = static_cast<lv_obj_t *>(lv_event_get_target(e));
+        auto index = lv_roller_get_selected(roller);
+        if (index >= Platform::CPU_MAX_FREQ_MHZ.size()) {
+          return;
+        }
+
+        // Takes effect immediately, save what was actually applied
+        auto &platform = Platform::getInstance();
+        platform.setCPUMaxFreq(Platform::CPU_MAX_FREQ_MHZ[index]);
+        Settings::save<Settings::CPU_FREQ>(platform.getCPUMaxFreq());
+      },
+      LV_EVENT_VALUE_CHANGED, NULL);
+
+  lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
+}
+
 void UI::addThemeMenu(const menu_t &parent) {
   menu_t &menu = addMenu(m_ThemeStr, &icon_palette, true, parent);
 
@@ -2077,6 +2133,7 @@ void UI::addSettingsMenu(void) {
   addThemeMenu(menu);
   addTransmitPowerMenu(menu);
   addAboutMenu(menu);
+  addPowerMenu(menu);
 
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -3,7 +3,11 @@
 #include <tuple>
 
 #include <M5Unified.h>
+#include <esp_chip_info.h>
+#include <esp_flash.h>
+#include <esp_idf_version.h>
 #include <esp_sleep.h>
+#include <esp_system.h>
 #include <lvgl.h>
 #include <src/themes/lv_theme_private.h>
 
@@ -70,7 +74,10 @@ std::unordered_map<const char *, UI::menu_t> UI::m_Menu = {
     {m_TransmitPowerStr,     {nullptr, nullptr, nullptr, nullptr, {1, 1}}},
     {m_AboutStr,             {nullptr, nullptr, nullptr, nullptr, {2, 1}}},
     {m_PowerStr,             {nullptr, nullptr, nullptr, nullptr, {3, 1}}},
+    {m_DiagnosticsStr,       {nullptr, nullptr, nullptr, nullptr, {0, 2}}},
     {m_BatteryStr,           {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
+    {m_DeviceInfoStr,        {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
+    {m_PowerStateStr,        {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_RemoteShutter,        {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_RemoteInterval,       {nullptr, nullptr, nullptr, nullptr, {1, 0}}},
     {m_RemoteDisconnect,     {nullptr, nullptr, nullptr, nullptr, {2, 0}}},
@@ -164,6 +171,10 @@ UI::UI(const interval_t &interval)
 
   // sample the battery every 5s, the PMIC is on I2C and the values move slowly
   m_BatteryTimer = lv_timer_create(batteryUpdate, 5000, &m_Status);
+
+  // refresh the diagnostics pages every second, but only while one is open
+  m_DiagnosticsTimer = lv_timer_create(diagnosticsUpdate, 1000, &m_Diagnostics);
+  lv_timer_pause(m_DiagnosticsTimer);
 
   // refresh icons every 250ms
   m_IconTimer = lv_timer_create(
@@ -902,6 +913,15 @@ void UI::addMainMenu(void) {
         auto *page = lv_menu_get_cur_main_page(target);
         auto *back = lv_menu_get_main_header_back_button(m_MainMenu.main);
         auto &scan = Scan::getInstance();
+
+        // the diagnostics values only refresh while one of their pages is open
+        if ((page == m_Menu.at(m_AboutStr).page) || (page == m_Menu.at(m_DeviceInfoStr).page)
+            || (page == m_Menu.at(m_PowerStateStr).page)) {
+          lv_timer_resume(ui->m_DiagnosticsTimer);
+          lv_timer_ready(ui->m_DiagnosticsTimer);
+        } else {
+          lv_timer_pause(ui->m_DiagnosticsTimer);
+        }
 
         if (page == m_MainMenu.page) {
           size_t saveCount = CameraList::getSaveCount();
@@ -2248,22 +2268,192 @@ void UI::addTransmitPowerMenu(const menu_t &parent) {
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }
 
+lv_obj_t *UI::addInfoRow(lv_obj_t *cont) {
+  lv_obj_t *label = lv_label_create(cont);
+  lv_obj_set_width(label, LV_PCT(100));
+  lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
+  lv_label_set_text(label, "");
+
+  // rows are read only, but must be focusable so the button boards can scroll
+  lv_obj_add_flag(label, LV_OBJ_FLAG_CLICKABLE);
+  lv_obj_add_flag(label, LV_OBJ_FLAG_SCROLL_ON_FOCUS);
+  lv_group_add_obj(lv_group_get_default(), label);
+
+  return label;
+}
+
+const char *UI::getResetReason(void) {
+  switch (esp_reset_reason()) {
+    case ESP_RST_POWERON:
+      return "Power on";
+    case ESP_RST_EXT:
+      return "External";
+    case ESP_RST_SW:
+      return "Software";
+    case ESP_RST_PANIC:
+      return "Panic";
+    case ESP_RST_INT_WDT:
+      return "Interrupt watchdog";
+    case ESP_RST_TASK_WDT:
+      return "Task watchdog";
+    case ESP_RST_WDT:
+      return "Watchdog";
+    case ESP_RST_DEEPSLEEP:
+      return "Deep sleep";
+    case ESP_RST_BROWNOUT:
+      return "Brownout";
+    default:
+      return "Unknown";
+  }
+}
+
+void UI::diagnosticsUpdate(lv_timer_t *timer) {
+  auto *diagnostics = static_cast<diagnostics_t *>(lv_timer_get_user_data(timer));
+  auto &platform = Platform::getInstance();
+
+  SpinValue::hms_t hms = SpinValue::toHMS(platform.tick());
+  uint32_t heap = esp_get_free_heap_size();
+  uint32_t minimum = esp_get_minimum_free_heap_size();
+
+  if (diagnostics->aboutUptime != nullptr) {
+    lv_label_set_text_fmt(diagnostics->aboutUptime, "Uptime:\n%02lu:%02lu:%02lu", hms.hours,
+                          hms.minutes, hms.seconds);
+  }
+
+  if (diagnostics->aboutHeap != nullptr) {
+    lv_label_set_text_fmt(diagnostics->aboutHeap, "Heap:\n%lu B, min %lu B", heap, minimum);
+  }
+
+  if (diagnostics->deviceUptime != nullptr) {
+    lv_label_set_text_fmt(diagnostics->deviceUptime, "Uptime:\n%02lu:%02lu:%02lu", hms.hours,
+                          hms.minutes, hms.seconds);
+  }
+
+  if (diagnostics->deviceHeap != nullptr) {
+    lv_label_set_text_fmt(diagnostics->deviceHeap, "Heap:\n%lu B, min %lu B", heap, minimum);
+  }
+
+  if ((diagnostics->powerFrequency != nullptr) || (diagnostics->powerSleep != nullptr)) {
+    auto pm = platform.getPMConfig();
+
+    if (diagnostics->powerFrequency != nullptr) {
+      lv_label_set_text_fmt(diagnostics->powerFrequency, "CPU:\n%u to %u MHz", pm.min_freq_mhz,
+                            pm.max_freq_mhz);
+    }
+
+    if (diagnostics->powerSleep != nullptr) {
+      lv_label_set_text_fmt(diagnostics->powerSleep, "Light sleep:\n%s",
+                            pm.light_sleep_enable ? "on" : "off");
+    }
+  }
+}
+
 void UI::addAboutMenu(const menu_t &parent) {
   menu_t &menu = addMenu(m_AboutStr, &icon_info, true, parent);
   lv_obj_t *cont = lv_menu_cont_create(menu.page);
-  lv_obj_set_size(cont, LV_PCT(100), LV_PCT(100));
+  lv_obj_set_width(cont, LV_PCT(100));
   lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
   lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
 
-  lv_obj_t *version = lv_label_create(cont);
-  lv_obj_set_width(version, LV_PCT(100));
-  lv_label_set_long_mode(version, LV_LABEL_LONG_WRAP);
+  lv_obj_t *version = addInfoRow(cont);
   lv_label_set_text_fmt(version, "Version:\n%s", FURBLE_VERSION);
 
-  lv_obj_t *id = lv_label_create(cont);
-  lv_obj_set_width(id, LV_PCT(100));
-  lv_label_set_long_mode(id, LV_LABEL_LONG_WRAP);
+  lv_obj_t *id = addInfoRow(cont);
   lv_label_set_text_fmt(id, "ID:\n%s", Device::getStringID().c_str());
+
+  lv_obj_t *build = addInfoRow(cont);
+  lv_label_set_text_fmt(build, "Build:\n%s %s", __DATE__, __TIME__);
+
+  lv_obj_t *idf = addInfoRow(cont);
+  lv_label_set_text_fmt(idf, "IDF:\n%s", IDF_VER);
+
+  // filled in by the diagnostics timer whenever the page is open
+  m_Diagnostics.aboutUptime = addInfoRow(cont);
+  m_Diagnostics.aboutHeap = addInfoRow(cont);
+
+  lv_obj_t *reset = addInfoRow(cont);
+  lv_label_set_text_fmt(reset, "Reset:\n%s", getResetReason());
+
+  lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
+}
+
+void UI::addDeviceInfoMenu(const menu_t &parent) {
+  menu_t &menu = addMenu(m_DeviceInfoStr, NULL, true, parent);
+  lv_obj_t *cont = lv_menu_cont_create(menu.page);
+  lv_obj_set_width(cont, LV_PCT(100));
+  lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+  esp_chip_info_t info;
+  esp_chip_info(&info);
+
+  uint32_t flash = 0;
+  esp_err_t err = esp_flash_get_size(NULL, &flash);
+  if (err != ESP_OK) {
+    ESP_LOGW("ui", "Unable to read flash size (%s).", esp_err_to_name(err));
+    flash = 0;
+  }
+
+  lv_obj_t *chip = addInfoRow(cont);
+  lv_label_set_text_fmt(chip, "Chip:\n%s rev %u.%u", CONFIG_IDF_TARGET, info.revision / 100,
+                        info.revision % 100);
+
+  lv_obj_t *cores = addInfoRow(cont);
+  lv_label_set_text_fmt(cores, "Cores: %u", info.cores);
+
+  lv_obj_t *size = addInfoRow(cont);
+  lv_label_set_text_fmt(size, "Flash: %lu MB", flash / (1024 * 1024));
+
+  // filled in by the diagnostics timer whenever the page is open
+  m_Diagnostics.deviceHeap = addInfoRow(cont);
+  m_Diagnostics.deviceUptime = addInfoRow(cont);
+
+  lv_obj_t *reset = addInfoRow(cont);
+  lv_label_set_text_fmt(reset, "Reset:\n%s", getResetReason());
+
+  lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
+}
+
+void UI::addPowerStateMenu(const menu_t &parent) {
+  menu_t &menu = addMenu(m_PowerStateStr, NULL, true, parent);
+  lv_obj_t *cont = lv_menu_cont_create(menu.page);
+  lv_obj_set_width(cont, LV_PCT(100));
+  lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+  // filled in by the diagnostics timer whenever the page is open
+  m_Diagnostics.powerFrequency = addInfoRow(cont);
+  m_Diagnostics.powerSleep = addInfoRow(cont);
+
+  lv_obj_t *tickless = addInfoRow(cont);
+  lv_label_set_text_fmt(tickless, "Tickless idle:\n%s", Platform::hasTicklessIdle() ? "yes" : "no");
+
+  lv_obj_t *configured = addInfoRow(cont);
+  lv_label_set_text(configured, "Frequencies are configured, not measured.");
+
+  lv_obj_t *dump = lv_button_create(cont);
+  lv_obj_t *label = lv_label_create(dump);
+  lv_label_set_text(label, "Dump locks");
+  lv_obj_add_event_cb(
+      dump, [](lv_event_t *e) { Platform::getInstance().dumpPMLocks(); }, LV_EVENT_CLICKED, NULL);
+
+  lv_obj_t *console = addInfoRow(cont);
+  lv_label_set_text(console, "Locks go to the serial console, without hold times.");
+
+  lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
+}
+
+void UI::addDiagnosticsMenu(const menu_t &parent) {
+  menu_t &menu = addMenu(m_DiagnosticsStr, &icon_info, true, parent);
+
+  addDeviceInfoMenu(menu);
+
+  // link the battery page rather than building a second one
+  auto &battery = m_Menu.at(m_BatteryStr);
+  lv_obj_t *button = addMenuItem(menu, &icon_battery_android_frame_full, m_BatteryStr);
+  lv_menu_set_load_page_event(menu.main, button, battery.page);
+
+  addPowerStateMenu(menu);
 
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }
@@ -2272,7 +2462,8 @@ void UI::addSettingsMenu(void) {
   menu_t &menu = addMenu(m_SettingsStr, &icon_settings);
 
 #if defined(FURBLE_M5COREX)
-  lv_obj_set_grid_dsc_array(menu.page, m_GridLayoutColDsc.data(), m_GridLayoutRowDsc.data());
+  lv_obj_set_grid_dsc_array(menu.page, m_GridLayoutColDsc.data(),
+                            m_SettingsGridLayoutRowDsc.data());
   lv_obj_set_layout(menu.page, LV_LAYOUT_GRID);
 #else
 #endif
@@ -2287,6 +2478,8 @@ void UI::addSettingsMenu(void) {
   addTransmitPowerMenu(menu);
   addAboutMenu(menu);
   addPowerMenu(menu);
+  // after 'Power', the battery page it builds is linked from diagnostics
+  addDiagnosticsMenu(menu);
 
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -70,6 +70,7 @@ std::unordered_map<const char *, UI::menu_t> UI::m_Menu = {
     {m_TransmitPowerStr,     {nullptr, nullptr, nullptr, nullptr, {1, 1}}},
     {m_AboutStr,             {nullptr, nullptr, nullptr, nullptr, {2, 1}}},
     {m_PowerStr,             {nullptr, nullptr, nullptr, nullptr, {3, 1}}},
+    {m_BatteryStr,           {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_RemoteShutter,        {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_RemoteInterval,       {nullptr, nullptr, nullptr, nullptr, {1, 0}}},
     {m_RemoteDisconnect,     {nullptr, nullptr, nullptr, nullptr, {2, 0}}},
@@ -144,31 +145,33 @@ UI::UI(const interval_t &interval)
   m_Status.gps = &m_GPS;
   m_Status.reconnectIcon = addIcon(&icon_all_inclusive);
   m_Status.gpsIcon = addIcon(&icon_location_disabled);
-#if FURBLE_BATTERY_DEBUG == 1
-  m_Status.batteryIcon = lv_label_create(m_Header);
-#else
   m_Status.batteryIcon = addIcon(&icon_battery_android_frame_4);
-#endif
+  m_Status.batteryLabel = lv_label_create(m_Header);
+  m_Status.batteryLevel = nullptr;
+  m_Status.batteryVoltage = nullptr;
+  m_Status.batteryCurrent = nullptr;
+  m_Status.batteryCharging = nullptr;
+  m_Status.batteryRuntime = nullptr;
   m_Status.screenLocked = false;
 
+  // prime the battery cache before anything renders it
+  m_Status.battery = Platform::getInstance().readBattery();
+  m_Status.meanCurrent = m_Status.battery.current;
+  lv_label_set_text_fmt(m_Status.batteryLabel, "%u%%", m_Status.battery.level);
+  setBatteryStyle(Settings::load<Settings::BATT_STYLE>());
+
   m_GPS.setIcon(m_Status.gpsIcon);
+
+  // sample the battery every 5s, the PMIC is on I2C and the values move slowly
+  m_BatteryTimer = lv_timer_create(batteryUpdate, 5000, &m_Status);
 
   // refresh icons every 250ms
   m_IconTimer = lv_timer_create(
       [](lv_timer_t *timer) {
         status_t *status = static_cast<status_t *>(lv_timer_get_user_data(timer));
 
-#if FURBLE_BATTERY_DEBUG == 1
-        int32_t current = M5.Power.getBatteryCurrent();
-        static int32_t mean = current;
-
-        // exponentially weighted moving average with alpha = 0.33
-        mean = mean + (current - mean) / 3;
-
-        lv_label_set_text_fmt(status->batteryIcon, "%ld", mean);
-#else
         const lv_image_dsc_t *symbol = NULL;
-        int32_t level = M5.Power.getBatteryLevel();
+        uint8_t level = status->battery.level;
         if (level >= 95) {
           symbol = &icon_battery_android_frame_full;
         } else if (level >= 66) {
@@ -181,7 +184,13 @@ UI::UI(const interval_t &interval)
           symbol = &icon_battery_android_0;
         }
         lv_image_set_src(status->batteryIcon, symbol);
-#endif
+
+        // the label only changes when the sampled level changes
+        static uint8_t rendered = UINT8_MAX;
+        if (rendered != level) {
+          rendered = level;
+          lv_label_set_text_fmt(status->batteryLabel, "%u%%", level);
+        }
 
         if (status->gps->isEnabled()) {
           lv_obj_clear_flag(status->gpsIcon, LV_OBJ_FLAG_HIDDEN);
@@ -949,6 +958,9 @@ void UI::addMainMenu(void) {
 
           m_ConnectContext.menuName = m_ScanStr;
         } else if (page == m_Menu.at(m_SettingsStr).page) {
+        } else if (page == m_Menu.at(m_BatteryStr).page) {
+          // refresh the battery page on entry rather than waiting for the timer
+          lv_timer_ready(ui->m_BatteryTimer);
         } else if (page == m_Menu.at(m_ConnectStr).page) {
           // ensure menu control
           // especially if arrived here from a disconnect/cancel
@@ -1950,10 +1962,124 @@ void UI::addDisplayMenu(const menu_t &parent) {
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }
 
+void UI::setBatteryStyle(uint8_t style) {
+  if (style == Settings::BATT_STYLE_PERCENT) {
+    lv_obj_add_flag(m_Status.batteryIcon, LV_OBJ_FLAG_HIDDEN);
+  } else {
+    lv_obj_clear_flag(m_Status.batteryIcon, LV_OBJ_FLAG_HIDDEN);
+  }
+
+  if (style == Settings::BATT_STYLE_ICON) {
+    lv_obj_add_flag(m_Status.batteryLabel, LV_OBJ_FLAG_HIDDEN);
+  } else {
+    lv_obj_clear_flag(m_Status.batteryLabel, LV_OBJ_FLAG_HIDDEN);
+  }
+}
+
+void UI::batteryUpdate(lv_timer_t *timer) {
+  auto *status = static_cast<status_t *>(lv_timer_get_user_data(timer));
+  auto &platform = Platform::getInstance();
+  const auto &caps = platform.getBatteryCaps();
+
+  status->battery = platform.readBattery();
+
+  if (caps.current) {
+    // exponentially weighted moving average with alpha = 1/12, at the 5s
+    // sample period that is a time constant of about a minute
+    status->meanCurrent += (status->battery.current - status->meanCurrent) / 12.0f;
+  }
+
+  if (status->batteryLevel != nullptr) {
+    lv_label_set_text_fmt(status->batteryLevel, "Level: %u%%", status->battery.level);
+  }
+
+  if (status->batteryVoltage != nullptr) {
+    lv_label_set_text_fmt(status->batteryVoltage, "Volts: %u.%03u", status->battery.voltage / 1000,
+                          status->battery.voltage % 1000);
+  }
+
+  if (status->batteryCurrent != nullptr) {
+    lv_label_set_text_fmt(status->batteryCurrent, "Current: %ld mA", status->battery.current);
+  }
+
+  if (status->batteryCharging != nullptr) {
+    lv_label_set_text(status->batteryCharging,
+                      status->battery.charging ? "Charging: yes" : "Charging: no");
+  }
+
+  if (status->batteryRuntime != nullptr) {
+    if (status->battery.charging) {
+      lv_label_set_text(status->batteryRuntime, "Runtime: charging");
+    } else if (status->meanCurrent < -1.0f) {
+      // remaining capacity in mAh divided by the average discharge current
+      float remaining = platform.getBatteryCapacity() * (status->battery.level / 100.0f);
+      uint32_t minutes = (remaining / -status->meanCurrent) * 60.0f;
+      lv_label_set_text_fmt(status->batteryRuntime, "Runtime: ~%luh%02lum (est)", minutes / 60,
+                            minutes % 60);
+    } else {
+      lv_label_set_text(status->batteryRuntime, "Runtime: unknown");
+    }
+  }
+
+#if FURBLE_BATTERY_DEBUG == 1
+  ESP_LOGI("battery", "uptime=%lu level=%u voltage=%u current=%ld mean=%.1f charging=%u fail=%lu",
+           platform.tick() / 1000, status->battery.level, status->battery.voltage,
+           status->battery.current, status->meanCurrent, status->battery.charging,
+           platform.getBatteryFailCount());
+#endif
+}
+
+void UI::addBatteryMenu(const menu_t &parent) {
+  menu_t &menu = addMenu(m_BatteryStr, &icon_battery_android_frame_full, true, parent);
+  auto &platform = Platform::getInstance();
+  const auto &caps = platform.getBatteryCaps();
+
+  lv_obj_t *cont = lv_menu_cont_create(menu.page);
+  lv_obj_set_width(cont, LV_PCT(100));
+  lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER);
+
+  auto addRow = [cont]() {
+    lv_obj_t *label = lv_label_create(cont);
+    lv_label_set_text(label, "");
+    lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+    lv_obj_set_width(label, LV_PCT(100));
+
+    return label;
+  };
+
+  // only add the rows this board can actually measure
+  if (caps.level) {
+    m_Status.batteryLevel = addRow();
+  }
+
+  if (caps.voltage) {
+    m_Status.batteryVoltage = addRow();
+  }
+
+  if (caps.current) {
+    m_Status.batteryCurrent = addRow();
+  }
+
+  if (caps.charging) {
+    m_Status.batteryCharging = addRow();
+  }
+
+  if (caps.current && (platform.getBatteryCapacity() > 0)) {
+    m_Status.batteryRuntime = addRow();
+  }
+
+  // fill the page with the current values
+  lv_timer_ready(m_BatteryTimer);
+
+  lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
+}
+
 void UI::addPowerMenu(const menu_t &parent) {
   menu_t &menu = addMenu(m_PowerStr, &icon_power_settings_new, true, parent);
   lv_obj_t *cont = lv_menu_cont_create(menu.page);
-  lv_obj_set_height(cont, LV_PCT(100));
+  lv_obj_set_width(cont, LV_PCT(100));
   lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
   lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER,
                         LV_FLEX_ALIGN_CENTER);
@@ -2001,6 +2127,33 @@ void UI::addPowerMenu(const menu_t &parent) {
         Settings::save<Settings::CPU_FREQ>(platform.getCPUMaxFreq());
       },
       LV_EVENT_VALUE_CHANGED, NULL);
+
+  // Add battery style control
+  label = lv_label_create(cont);
+  lv_label_set_text(label, Settings::get(Settings::BATT_STYLE).name);
+  lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
+  lv_obj_set_width(label, LV_PCT(100));
+
+  roller = lv_roller_create(cont);
+  lv_obj_set_width(roller, LV_PCT(90));
+  lv_roller_set_options(roller, "Icon\nPercent\nBoth", LV_ROLLER_MODE_INFINITE);
+  lv_roller_set_visible_row_count(roller, 2);
+  lv_roller_set_selected(roller, Settings::load<Settings::BATT_STYLE>(), LV_ANIM_OFF);
+
+  lv_obj_add_event_cb(
+      roller,
+      [](lv_event_t *e) {
+        auto *ui = static_cast<UI *>(lv_event_get_user_data(e));
+        auto *roller = static_cast<lv_obj_t *>(lv_event_get_target(e));
+        uint8_t style = lv_roller_get_selected(roller);
+
+        Settings::save<Settings::BATT_STYLE>(style);
+        ui->setBatteryStyle(style);
+      },
+      LV_EVENT_VALUE_CHANGED, this);
+
+  // Add the battery page entry below the controls
+  addBatteryMenu(menu);
 
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,11 @@ void app_main() {
 
   Furble::Platform::init();
   Furble::Settings::init();
+
+  // Platform::init() runs before NVS exists, apply the stored frequency now
+  Furble::Platform::getInstance().setCPUMaxFreq(
+      Furble::Settings::load<Furble::Settings::CPU_FREQ>());
+
   Furble::Device::init(Furble::Settings::load<esp_power_level_t>(Furble::Settings::TX_POWER));
 
   auto &control = Furble::Control::getInstance();


### PR DESCRIPTION
Closes #295.

There is no way to see battery detail, uptime, heap, reset reason or power state on the device, so diagnosing a problem in the field means guessing or reflashing a debug build. This PR expands About with build info, uptime, heap and reset reason, and adds a read only Settings -> Diagnostics page holding device info, the battery page from #290, and a power state page with a serial console lock dump. Values refresh once a second only while one of those pages is open, there are no new settings and no behaviour changes; the Core settings grid grew to three rows without touching the main menu layout. Depends on #290 and through it #287.

Build verified for m5stick-s3, m5stick-c-plus and m5stack-core2. Not yet hardware tested. There are no BLE changes, so camera behaviour is unaffected.

Plan document: https://github.com/MaxRink/furble/blob/plans/plans/05-diagnostics-scaffold.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)