### PR TITLE
Add GPS receiver configuration with PCAS commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,20 @@ The default baud rate for the GPS unit is 9600.
 The new v1.1 unit runs at a higher baud rate and must be configured under
 `Settings->GPS->GPS baud 115200` for correct operation.
 
+The GPS receiver itself can also be configured under `Settings->GPS`:
+- `Update rate` (how often the receiver reports a position, from 1000ms down to 100ms)
+- `Sentences` (cut the receiver down to the sentences `furble` actually reads)
+- `Constellation` (which satellite systems the receiver listens to)
+
+Each of these defaults to `Default`, which leaves the receiver on its own
+settings and behaves exactly as before.
+A change is sent to the receiver when GPS is enabled, and the receiver goes
+back to its own defaults the next time it is powered off.
+
+`Settings->GPS->Raw NMEA` shows the sentences arriving from the receiver along
+with the fix state and error counts.
+It is the place to look to confirm the receiver accepted a change.
+
 ### Intervalometer/Timer
 
 The intervalometer can be configured via three settings in `Settings->Timer`:

--- a/include/FurbleGPS.h
+++ b/include/FurbleGPS.h
@@ -1,6 +1,12 @@
 #ifndef FURBLE_GPS_H
 #define FURBLE_GPS_H
 
+#include <array>
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <vector>
+
 #include <driver/uart.h>
 
 #include <lvgl.h>
@@ -29,6 +35,21 @@ class GPS {
   void reset(void);
   void task(void);
 
+  /** Fix interval in milliseconds for each rate setting. */
+  static constexpr const std::array<uint16_t, 5> RATE_MS = {0, 1000, 500, 200, 100};
+
+  /** Highest valid constellation setting. */
+  static constexpr const uint8_t CONSTELLATION_MAX = 7;
+
+  /** Restart the receiver, 0 hot, 1 warm, 2 cold. */
+  void restart(uint8_t mode);
+
+  /** Capture raw NMEA sentences for the debug page. */
+  void setCapture(bool capture);
+
+  /** Get the captured NMEA sentences, oldest first. */
+  std::vector<std::string> getSentences(void);
+
  private:
   GPS() {};
 
@@ -37,10 +58,35 @@ class GPS {
   static constexpr const uint16_t SERVICE_MS = 1000;
   static constexpr const uint32_t MAX_AGE_MS = 30 * 1000;
 
+  /** How long to wait for the receiver before sending the configuration. */
+  static constexpr const uint32_t SETTLE_MS = 3000;
+
+  /** How long to wait for a command to leave the UART. */
+  static constexpr const uint32_t TX_MS = 100;
+
+  /** Number of raw NMEA sentences kept for the debug page. */
+  static constexpr const size_t SENTENCES = 8;
+
+  /** Longest raw NMEA sentence kept for the debug page. */
+  static constexpr const size_t SENTENCE_LEN = 96;
+
   void enable(void);
   void disable(void);
   void serviceSerial(void);
+  void serviceConfig(void);
   void update(void);
+
+  /** XOR checksum of every character between '$' and '*'. */
+  static uint8_t checksum(const std::string &payload);
+
+  /** Frame the payload as NMEA and write it to the receiver. */
+  void sendCommand(const std::string &payload);
+
+  /** Send the $PCAS configuration commands for the current settings. */
+  void configure(void);
+
+  /** Store raw NMEA sentences while the debug page is open. */
+  void captureSentences(const char *data, size_t length);
 
   uart_port_t m_UART = UART_NUM_2;
 
@@ -53,6 +99,16 @@ class GPS {
   bool m_Enabled = false;
   bool m_HasFix = false;
   TinyGPSPlus m_GPS;
+
+  std::atomic<bool> m_ConfigPending = false;
+  uint32_t m_ConfigStart = 0;
+  uint32_t m_ConfigChars = 0;
+
+  std::atomic<bool> m_Capture = false;
+  std::mutex m_CaptureMutex;
+  std::array<std::string, SENTENCES> m_Sentences;
+  size_t m_SentenceNext = 0;
+  std::string m_Partial;
 };
 }  // namespace Furble
 

--- a/include/FurbleSettings.h
+++ b/include/FurbleSettings.h
@@ -20,6 +20,9 @@ class Settings {
     TX_POWER,
     GPS,
     GPS_BAUD,
+    GPS_RATE,
+    GPS_NMEA,
+    GPS_CONSTEL,
     INTERVAL,
     MULTICONNECT,
     RECONNECT,
@@ -121,6 +124,18 @@ struct Settings::storage_type<Settings::GPS> {
 template <>
 struct Settings::storage_type<Settings::GPS_BAUD> {
   using type = uint32_t;
+};
+template <>
+struct Settings::storage_type<Settings::GPS_RATE> {
+  using type = uint8_t;
+};
+template <>
+struct Settings::storage_type<Settings::GPS_NMEA> {
+  using type = bool;
+};
+template <>
+struct Settings::storage_type<Settings::GPS_CONSTEL> {
+  using type = uint8_t;
 };
 template <>
 struct Settings::storage_type<Settings::INTERVAL> {

--- a/include/FurbleUI.h
+++ b/include/FurbleUI.h
@@ -69,10 +69,17 @@ class UI {
     lv_obj_t *gpsIcon;
     lv_obj_t *batteryIcon;
     lv_obj_t *reconnectIcon;
-    lv_obj_t *gpsBaud;
-    lv_obj_t *gpsData;
+    /** Widgets which are only useful while GPS is enabled. */
+    std::vector<lv_obj_t *> gpsWidgets;
     bool screenLocked;
   } status_t;
+
+  /** Labels on the raw NMEA page. */
+  typedef struct {
+    lv_obj_t *fix;
+    lv_obj_t *counters;
+    lv_obj_t *sentences;
+  } nmea_t;
 
   class Intervalometer {
    public:
@@ -183,6 +190,16 @@ class UI {
 
   // settings->gps
   static constexpr const char *m_GPSDataStr = "GPS Data";
+  static constexpr const char *m_GPSRateStr = "Update rate";
+  static constexpr const char *m_GPSSentencesStr = "Sentences";
+  static constexpr const char *m_GPSConstellationStr = "Constellation";
+  static constexpr const char *m_GPSNMEAStr = "Raw NMEA";
+
+  // settings->gps rollers
+  static constexpr const char *m_GPSRateOptions = "Default\n1000 ms\n500 ms\n200 ms\n100 ms";
+  static constexpr const char *m_GPSSentencesOptions = "Default\nRMC+GGA";
+  static constexpr const char *m_GPSConstellationOptions =
+      "Default\nGPS\nBDS\nGPS+BDS\nGLONASS\nGPS+GLO\nBDS+GLO\nAll";
 
   // settings->intervalometer
   static constexpr const char *m_IntervalCountStr = "Count";
@@ -249,6 +266,8 @@ class UI {
   Intervalometer m_Intervalometer;
 
   status_t m_Status;
+  nmea_t m_NMEA;
+  lv_timer_t *m_NMEATimer = nullptr;
   bool m_FocusPressed = false;
   bool m_ShutterLock = false;
   uint32_t m_InactivityTimeout;
@@ -319,8 +338,24 @@ class UI {
   /** Add the 'Delete' menu entry. */
   void addDeleteMenu(void);
 
-  /** Add 'GPS Data' page. */
+  /** Add the 'GPS' menu entry. */
   void addGPSMenu(const menu_t &parent);
+
+  /** Add 'GPS Data' page. */
+  void addGPSDataMenu(const menu_t &parent);
+
+  /** Add a GPS option page holding a single roller. */
+  void addGPSOptionMenu(const menu_t &parent,
+                        const char *name,
+                        const char *options,
+                        uint32_t selected,
+                        lv_event_cb_t handler);
+
+  /** Add the raw NMEA and satellite debug page. */
+  void addGPSNMEAMenu(const menu_t &parent);
+
+  /** Show or hide the widgets which need GPS enabled. */
+  static void showGPSWidgets(status_t *status, bool show);
 
   /** Add the 'Features' menu entry. */
   void addFeaturesMenu(const menu_t &parent);
@@ -353,6 +388,9 @@ class UI {
 
   /** Stop GPS Data timer. */
   static void gpsDataStop(lv_event_t *e);
+
+  /** Stop the raw NMEA timer and capture. */
+  static void gpsNMEAStop(lv_event_t *e);
 
   /** Handle connection request. */
   static void doConnect(lv_event_t *e);

--- a/src/FurbleGPS.cpp
+++ b/src/FurbleGPS.cpp
@@ -76,7 +76,9 @@ void GPS::task(void) {
     if (!m_Enabled) {
       vTaskDelay(pdMS_TO_TICKS(100));
       continue;
-    } else if (xQueueReceive(m_Queue, &event, pdMS_TO_TICKS(100))) {
+    }
+
+    if (xQueueReceive(m_Queue, &event, pdMS_TO_TICKS(100))) {
       switch (event.type) {
         case UART_DATA:
           break;
@@ -105,6 +107,8 @@ void GPS::task(void) {
           break;
       }
     }
+
+    serviceConfig();
   }
 }
 
@@ -121,9 +125,94 @@ void GPS::enable(void) {
   // ESP32S3 UART does not function with light sleep
   Platform::getInstance().setSleep(false);
 #endif
+
+  // the receiver is not ready for commands yet, ask the GPS task to configure
+  // it once sentences arrive
+  m_ConfigChars = m_GPS.charsProcessed();
+  m_ConfigStart = Platform::getInstance().tick();
+  m_ConfigPending = true;
+}
+
+/** XOR of every character between '$' and '*', both excluded. */
+uint8_t GPS::checksum(const std::string &payload) {
+  uint8_t sum = 0;
+
+  for (const char c : payload) {
+    sum ^= static_cast<uint8_t>(c);
+  }
+
+  return sum;
+}
+
+/** Frame the payload as an NMEA sentence and send it to the receiver. */
+void GPS::sendCommand(const std::string &payload) {
+  std::array<char, 4> suffix;
+
+  snprintf(suffix.data(), suffix.size(), "*%02X", checksum(payload));
+  const std::string command = "$" + payload + suffix.data() + "\r\n";
+
+  ESP_LOGI(LOG_TAG, "GPS command: %s", payload.c_str());
+
+  uart_write_bytes(m_UART, command.data(), command.size());
+  uart_wait_tx_done(m_UART, pdMS_TO_TICKS(TX_MS));
+}
+
+/** Restart the receiver, 0 hot, 1 warm, 2 cold. */
+void GPS::restart(uint8_t mode) {
+  if (!m_Enabled || (mode > 2)) {
+    return;
+  }
+
+  sendCommand("PCAS10," + std::to_string(mode));
+}
+
+/**
+ * Send the $PCAS configuration commands.
+ *
+ * Every setting defaults to 'do not send', so a device which has never been
+ * configured leaves the receiver at its own defaults.
+ */
+void GPS::configure(void) {
+  const uint8_t rate = Settings::load<Settings::GPS_RATE>();
+  const bool prune = Settings::load<Settings::GPS_NMEA>();
+  const uint8_t constellation = Settings::load<Settings::GPS_CONSTEL>();
+
+  // prune first, the receiver cannot sustain the fast rates while it still
+  // emits every sentence
+  if (prune) {
+    // GGA for altitude, satellites and fix quality, RMC for date, time and
+    // position, nothing else is used
+    sendCommand("PCAS03,1,0,0,0,1,0,0,0");
+  }
+
+  if ((rate > 0) && (rate < RATE_MS.size())) {
+    sendCommand("PCAS02," + std::to_string(RATE_MS[rate]));
+  }
+
+  if ((constellation > 0) && (constellation <= CONSTELLATION_MAX)) {
+    sendCommand("PCAS04," + std::to_string(constellation));
+  }
+}
+
+/** Configure the receiver once it is awake, or give up and try anyway. */
+void GPS::serviceConfig(void) {
+  if (!m_Enabled || !m_ConfigPending) {
+    return;
+  }
+
+  const bool awake = m_GPS.charsProcessed() > m_ConfigChars;
+  const bool expired = (Platform::getInstance().tick() - m_ConfigStart) > SETTLE_MS;
+  if (!awake && !expired) {
+    return;
+  }
+
+  m_ConfigPending = false;
+  configure();
 }
 
 void GPS::disable(void) {
+  m_ConfigPending = false;
+
   // power off
   M5.Power.setExtOutput(false, m5::ext_PA);
 
@@ -202,7 +291,61 @@ void GPS::serviceSerial(void) {
   int bytes = uart_read_bytes(m_UART, buffer.data(), buffer.size(), 1);
   if (bytes > 0) {
     m_GPS.encode(reinterpret_cast<char *>(buffer.data()), bytes);
+    captureSentences(reinterpret_cast<char *>(buffer.data()), bytes);
   }
+}
+
+/** Split the raw stream into sentences for the debug page. */
+void GPS::captureSentences(const char *data, size_t length) {
+  if (!m_Capture) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(m_CaptureMutex);
+
+  for (size_t i = 0; i < length; i++) {
+    const char c = data[i];
+
+    if ((c == '\r') || (c == '\n')) {
+      if (!m_Partial.empty()) {
+        m_Sentences[m_SentenceNext] = m_Partial;
+        m_SentenceNext = (m_SentenceNext + 1) % m_Sentences.size();
+        m_Partial.clear();
+      }
+    } else if (m_Partial.size() < SENTENCE_LEN) {
+      m_Partial += c;
+    }
+  }
+}
+
+/** Start or stop raw NMEA sentence capture. */
+void GPS::setCapture(bool capture) {
+  std::lock_guard<std::mutex> lock(m_CaptureMutex);
+
+  m_Capture = capture;
+  if (!capture) {
+    for (auto &sentence : m_Sentences) {
+      sentence.clear();
+    }
+    m_SentenceNext = 0;
+    m_Partial.clear();
+  }
+}
+
+/** Get the captured raw NMEA sentences, oldest first. */
+std::vector<std::string> GPS::getSentences(void) {
+  std::vector<std::string> sentences;
+
+  std::lock_guard<std::mutex> lock(m_CaptureMutex);
+
+  for (size_t i = 0; i < m_Sentences.size(); i++) {
+    const auto &sentence = m_Sentences[(m_SentenceNext + i) % m_Sentences.size()];
+    if (!sentence.empty()) {
+      sentences.push_back(sentence);
+    }
+  }
+
+  return sentences;
 }
 
 TinyGPSPlus &GPS::get(void) {

--- a/src/FurbleSettings.cpp
+++ b/src/FurbleSettings.cpp
@@ -15,6 +15,9 @@ const std::unordered_map<Settings::type_t, Settings::setting_t> Settings::m_Sett
     {TX_POWER,          {TX_POWER, "TX Power", "tx_power", FURBLE_STR}                 },
     {GPS,               {GPS, "GPS", "gps", FURBLE_STR}                                },
     {GPS_BAUD,          {GPS_BAUD, "GPS Baud", "gps_baud", FURBLE_STR}                 },
+    {GPS_RATE,          {GPS_RATE, "GPS Rate", "gps_rate", FURBLE_STR}                 },
+    {GPS_NMEA,          {GPS_NMEA, "GPS Sentences", "gps_nmea", FURBLE_STR}            },
+    {GPS_CONSTEL,       {GPS_CONSTEL, "GPS Constellation", "gps_constel", FURBLE_STR}  },
     {INTERVAL,          {INTERVAL, "Interval", "interval", FURBLE_STR}                 },
     {MULTICONNECT,      {MULTICONNECT, "Multi-Connect", "multiconnect", FURBLE_STR}    },
     {RECONNECT,         {RECONNECT, "Infinite-ReConnect", "reconnect", FURBLE_STR}     },
@@ -194,6 +197,8 @@ void Settings::init(void) {
           save<std::string>(setting.type, "Default");
           break;
         case TX_POWER:
+        case GPS_RATE:
+        case GPS_CONSTEL:
           save<uint8_t>(setting.type, 0);
           break;
         case INTERVAL:
@@ -207,6 +212,7 @@ void Settings::init(void) {
           save<interval_t>(setting.type, interval);
         } break;
         case GPS:
+        case GPS_NMEA:
         case MULTICONNECT:
         case RECONNECT:
         case FAUXNY:

--- a/src/FurbleUI.cpp
+++ b/src/FurbleUI.cpp
@@ -60,6 +60,10 @@ std::unordered_map<const char *, UI::menu_t> UI::m_Menu = {
     {m_FeaturesStr,          {nullptr, nullptr, nullptr, nullptr, {1, 0}}},
     {m_GPSStr,               {nullptr, nullptr, nullptr, nullptr, {2, 0}}},
     {m_GPSDataStr,           {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
+    {m_GPSRateStr,           {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
+    {m_GPSSentencesStr,      {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
+    {m_GPSConstellationStr,  {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
+    {m_GPSNMEAStr,           {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_IntervalometerStr,    {nullptr, nullptr, nullptr, nullptr, {3, 0}}},
     {m_IntervalCountStr,     {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
     {m_IntervalDelayStr,     {nullptr, nullptr, nullptr, nullptr, {0, 0}}},
@@ -736,13 +740,7 @@ void UI::addSettingItem(lv_obj_t *page, const char *symbol, Settings::type_t set
         [](lv_event_t *e) {
           auto *status = static_cast<status_t *>(lv_event_get_user_data(e));
           status->gps->reloadSetting();
-          if (status->gps->isEnabled()) {
-            lv_obj_clear_flag(status->gpsBaud, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_clear_flag(status->gpsData, LV_OBJ_FLAG_HIDDEN);
-          } else {
-            lv_obj_add_flag(status->gpsBaud, LV_OBJ_FLAG_HIDDEN);
-            lv_obj_add_flag(status->gpsData, LV_OBJ_FLAG_HIDDEN);
-          }
+          showGPSWidgets(status, status->gps->isEnabled());
         },
         LV_EVENT_VALUE_CHANGED, &m_Status);
   }
@@ -1511,6 +1509,16 @@ void UI::addDeleteMenu(void) {
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 }
 
+void UI::showGPSWidgets(status_t *status, bool show) {
+  for (auto *widget : status->gpsWidgets) {
+    if (show) {
+      lv_obj_clear_flag(widget, LV_OBJ_FLAG_HIDDEN);
+    } else {
+      lv_obj_add_flag(widget, LV_OBJ_FLAG_HIDDEN);
+    }
+  }
+}
+
 void UI::addGPSMenu(const menu_t &parent) {
   menu_t &menu = addMenu(m_GPSStr, &icon_location_searching, true, parent);
 
@@ -1518,14 +1526,15 @@ void UI::addGPSMenu(const menu_t &parent) {
   lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
 
   // add GPS baud control
-  m_Status.gpsBaud = lv_menu_cont_create(menu.page);
-  lv_obj_set_flex_flow(m_Status.gpsBaud, LV_FLEX_FLOW_ROW_WRAP);
-  lv_obj_t *label = lv_label_create(m_Status.gpsBaud);
+  lv_obj_t *gpsBaud = lv_menu_cont_create(menu.page);
+  lv_obj_set_flex_flow(gpsBaud, LV_FLEX_FLOW_ROW_WRAP);
+  m_Status.gpsWidgets.push_back(gpsBaud);
+  lv_obj_t *label = lv_label_create(gpsBaud);
   lv_label_set_text(label, "GPS baud 115200");
   lv_label_set_long_mode(label, LV_LABEL_LONG_SCROLL_CIRCULAR);
   lv_obj_set_flex_grow(label, 1);
 
-  lv_obj_t *baud_sw = lv_switch_create(m_Status.gpsBaud);
+  lv_obj_t *baud_sw = lv_switch_create(gpsBaud);
   uint32_t baud = Settings::load<Settings::GPS_BAUD>();
   lv_obj_add_state(baud_sw, baud == Settings::BAUD_115200 ? LV_STATE_CHECKED : LV_STATE_DEFAULT);
   lv_obj_add_event_cb(
@@ -1545,12 +1554,73 @@ void UI::addGPSMenu(const menu_t &parent) {
       },
       LV_EVENT_VALUE_CHANGED, &m_Status);
 
-  menu_t &gpsData = addMenu(m_GPSDataStr, NULL, true, menu);
-  m_Status.gpsData = gpsData.button;
-  if (!m_Status.gps->isEnabled()) {
-    lv_obj_add_flag(m_Status.gpsBaud, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_add_flag(m_Status.gpsData, LV_OBJ_FLAG_HIDDEN);
-  }
+  // add the receiver configuration pages
+  addGPSOptionMenu(
+      menu, m_GPSRateStr, m_GPSRateOptions, Settings::load<Settings::GPS_RATE>(),
+      [](lv_event_t *e) {
+        auto *status = static_cast<status_t *>(lv_event_get_user_data(e));
+        auto *roller = static_cast<lv_obj_t *>(lv_event_get_target(e));
+
+        Settings::save<Settings::GPS_RATE>(static_cast<uint8_t>(lv_roller_get_selected(roller)));
+        status->gps->reloadSetting();
+      });
+
+  addGPSOptionMenu(menu, m_GPSSentencesStr, m_GPSSentencesOptions,
+                   Settings::load<Settings::GPS_NMEA>() ? 1 : 0, [](lv_event_t *e) {
+                     auto *status = static_cast<status_t *>(lv_event_get_user_data(e));
+                     auto *roller = static_cast<lv_obj_t *>(lv_event_get_target(e));
+
+                     Settings::save<Settings::GPS_NMEA>(lv_roller_get_selected(roller) > 0);
+                     status->gps->reloadSetting();
+                   });
+
+  addGPSOptionMenu(
+      menu, m_GPSConstellationStr, m_GPSConstellationOptions,
+      Settings::load<Settings::GPS_CONSTEL>(), [](lv_event_t *e) {
+        auto *status = static_cast<status_t *>(lv_event_get_user_data(e));
+        auto *roller = static_cast<lv_obj_t *>(lv_event_get_target(e));
+
+        Settings::save<Settings::GPS_CONSTEL>(static_cast<uint8_t>(lv_roller_get_selected(roller)));
+        status->gps->reloadSetting();
+      });
+
+  addGPSDataMenu(menu);
+  addGPSNMEAMenu(menu);
+
+  showGPSWidgets(&m_Status, m_Status.gps->isEnabled());
+}
+
+void UI::addGPSOptionMenu(const menu_t &parent,
+                          const char *name,
+                          const char *options,
+                          uint32_t selected,
+                          lv_event_cb_t handler) {
+  menu_t &menu = addMenu(name, NULL, true, parent);
+  m_Status.gpsWidgets.push_back(menu.button);
+
+  lv_obj_t *cont = lv_menu_cont_create(menu.page);
+  lv_obj_set_size(cont, LV_PCT(100), LV_PCT(100));
+  lv_obj_set_layout(cont, LV_LAYOUT_FLEX);
+  lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+  lv_obj_t *roller = lv_roller_create(cont);
+#if !defined(FURBLE_M5COREX)
+  lv_obj_set_width(roller, LV_PCT(90));
+#endif
+  lv_obj_add_flag(roller, LV_OBJ_FLAG_SCROLL_ON_FOCUS);
+  lv_roller_set_options(roller, options, LV_ROLLER_MODE_NORMAL);
+  lv_roller_set_visible_row_count(roller, 2);
+  lv_roller_set_selected(roller, selected, LV_ANIM_OFF);
+
+  lv_obj_add_event_cb(roller, handler, LV_EVENT_VALUE_CHANGED, &m_Status);
+
+  lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
+}
+
+void UI::addGPSDataMenu(const menu_t &parent) {
+  menu_t &gpsData = addMenu(m_GPSDataStr, NULL, true, parent);
+  m_Status.gpsWidgets.push_back(gpsData.button);
 
   static lv_timer_t *timer = lv_timer_create(
       [](lv_timer_t *t) {
@@ -1608,6 +1678,85 @@ void UI::gpsDataStop(lv_event_t *e) {
   auto *target = static_cast<lv_obj_t *>(lv_event_get_target(e));
   lv_timer_pause(timer);
   lv_obj_remove_event_cb(target, gpsDataStop);
+}
+
+/**
+ * Raw NMEA and satellite debug page.
+ *
+ * Sentence capture only runs while the page is open, it is the only way to
+ * observe whether a $PCAS command was accepted.
+ */
+void UI::addGPSNMEAMenu(const menu_t &parent) {
+  menu_t &menu = addMenu(m_GPSNMEAStr, NULL, true, parent);
+  m_Status.gpsWidgets.push_back(menu.button);
+
+  lv_obj_t *cont = lv_menu_cont_create(menu.page);
+  lv_obj_set_size(cont, LV_PCT(100), LV_SIZE_CONTENT);
+  lv_obj_set_layout(cont, LV_LAYOUT_FLEX);
+  lv_obj_set_flex_flow(cont, LV_FLEX_FLOW_COLUMN);
+
+  m_NMEA.fix = lv_label_create(cont);
+  lv_obj_set_width(m_NMEA.fix, LV_PCT(100));
+  lv_label_set_long_mode(m_NMEA.fix, LV_LABEL_LONG_WRAP);
+
+  m_NMEA.counters = lv_label_create(cont);
+  lv_obj_set_width(m_NMEA.counters, LV_PCT(100));
+  lv_label_set_long_mode(m_NMEA.counters, LV_LABEL_LONG_WRAP);
+
+  m_NMEA.sentences = lv_label_create(cont);
+  lv_obj_set_width(m_NMEA.sentences, LV_PCT(100));
+  lv_label_set_long_mode(m_NMEA.sentences, LV_LABEL_LONG_WRAP);
+  lv_obj_set_style_text_font(m_NMEA.sentences, &lv_font_montserrat_12, 0);
+
+  lv_obj_t *restart = lv_button_create(cont);
+  lv_obj_t *label = lv_label_create(restart);
+  lv_label_set_text(label, "Hot restart");
+  lv_obj_add_flag(restart, LV_OBJ_FLAG_SCROLL_ON_FOCUS);
+  lv_obj_add_event_cb(
+      restart, [](lv_event_t *e) { GPS::getInstance().restart(0); }, LV_EVENT_CLICKED, NULL);
+
+  m_NMEATimer = lv_timer_create(
+      [](lv_timer_t *t) {
+        auto *ui = static_cast<UI *>(lv_timer_get_user_data(t));
+        auto &gps = GPS::getInstance();
+        auto &tinygps = gps.get();
+
+        lv_label_set_text_fmt(ui->m_NMEA.fix, "%lu sats, hdop %.1f\n%lus ago",
+                              (unsigned long)tinygps.satellites.value(), tinygps.hdop.hdop(),
+                              (unsigned long)(tinygps.location.age() / 1000));
+        lv_label_set_text_fmt(
+            ui->m_NMEA.counters, "rx %lu\nok %lu, bad %lu", (unsigned long)tinygps.charsProcessed(),
+            (unsigned long)tinygps.passedChecksum(), (unsigned long)tinygps.failedChecksum());
+
+        std::string text;
+        for (const auto &sentence : gps.getSentences()) {
+          text += sentence + "\n";
+        }
+        lv_label_set_text(ui->m_NMEA.sentences, text.c_str());
+      },
+      1000, this);
+  lv_timer_pause(m_NMEATimer);
+
+  // only capture sentences while the page is open
+  lv_obj_add_event_cb(
+      menu.button,
+      [](lv_event_t *e) {
+        auto *ui = static_cast<UI *>(lv_event_get_user_data(e));
+        GPS::getInstance().setCapture(true);
+        lv_timer_resume(ui->m_NMEATimer);
+        lv_obj_add_event_cb(m_MainMenu.main, gpsNMEAStop, LV_EVENT_CLICKED, ui);
+      },
+      LV_EVENT_CLICKED, this);
+
+  lv_menu_set_load_page_event(menu.main, menu.button, menu.page);
+}
+
+void UI::gpsNMEAStop(lv_event_t *e) {
+  auto *ui = static_cast<UI *>(lv_event_get_user_data(e));
+  auto *target = static_cast<lv_obj_t *>(lv_event_get_target(e));
+  lv_timer_pause(ui->m_NMEATimer);
+  GPS::getInstance().setCapture(false);
+  lv_obj_remove_event_cb(target, gpsNMEAStop);
 }
 
 void UI::addFeaturesMenu(const menu_t &parent) {


### PR DESCRIPTION
Closes #302.

The GPS receiver always runs at its own defaults. It emits every NMEA sentence at 1 Hz across all constellations, which wastes UART traffic and power, and the update rate cannot be tuned. This adds a command path to the receiver for the fix interval ($PCAS02), the sentence output ($PCAS03) and the constellation ($PCAS04), plus a raw NMEA page to observe the result. Settings -> GPS becomes a submenu, and every new setting defaults to "do not send" so a fresh install behaves exactly as before. $PCAS00 is never sent, so the receiver returns to its own defaults on a power cycle.

Build verified on all five environments. Hardware verification on the AT6668 unit is still pending, so the command values are provisional. GEOTAG on Fujifilm is the only vendor path that consumes GPS data, other vendors are unaffected.

Plan document: https://github.com/MaxRink/furble/blob/plans/plans/14-gps-pcas.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)