### PR TITLE
Add Fujifilm X100VI to supported cameras

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following devices have been tested and confirmed to work:
    - Fujifilm X-T30
    - Fujifilm X-T4 ([@TomaszLojewski](https://github.com/TomaszLojewski))
    - Fujifilm X-T5 ([@stulevine](https://github.com/stulevine))
-   - Fujifilm X100V
+   - Fujifilm X100V / X100VI
 - Canon
    - Canon EOS M6 ([@tardisx](https://github.com/tardisx))
    - Canon EOS R6 Mark II ([@hijae](https://github.com/hijae))


### PR DESCRIPTION
I tested furble with a Fujifilm X100VI and an X-E5. Both work: scanning, pairing, shutter release and GPS geotagging. The X-E5 is already listed, so this adds the X100VI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)